### PR TITLE
[#4] ExceptionHandler, CustomException 공통 사항 적용

### DIFF
--- a/src/main/java/kr/pickple/back/common/dto/ExceptionResponse.java
+++ b/src/main/java/kr/pickple/back/common/dto/ExceptionResponse.java
@@ -1,0 +1,19 @@
+package kr.pickple.back.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExceptionResponse {
+
+    private final String code;
+    private final String message;
+    private final Object[] rejectedValues;
+
+    @Builder
+    protected ExceptionResponse(String code, String message, Object[] rejectedValues) {
+        this.code = code;
+        this.message = message;
+        this.rejectedValues = rejectedValues;
+    }
+}

--- a/src/main/java/kr/pickple/back/common/dto/ExceptionResponse.java
+++ b/src/main/java/kr/pickple/back/common/dto/ExceptionResponse.java
@@ -1,16 +1,11 @@
 package kr.pickple.back.common.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@Builder
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor(staticName = "from")
 public class ExceptionResponse {
 
     private final String code;
-    private final String message;
-    private final Object[] rejectedValues;
 }

--- a/src/main/java/kr/pickple/back/common/dto/ExceptionResponse.java
+++ b/src/main/java/kr/pickple/back/common/dto/ExceptionResponse.java
@@ -1,19 +1,16 @@
 package kr.pickple.back.common.dto;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@Builder
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExceptionResponse {
 
     private final String code;
     private final String message;
     private final Object[] rejectedValues;
-
-    @Builder
-    protected ExceptionResponse(String code, String message, Object[] rejectedValues) {
-        this.code = code;
-        this.message = message;
-        this.rejectedValues = rejectedValues;
-    }
 }

--- a/src/main/java/kr/pickple/back/common/exception/BusinessException.java
+++ b/src/main/java/kr/pickple/back/common/exception/BusinessException.java
@@ -3,7 +3,7 @@ package kr.pickple.back.common.exception;
 import lombok.Getter;
 
 @Getter
-abstract class BusinessException extends RuntimeException {
+public abstract class BusinessException extends RuntimeException {
 
     private final ExceptionCode exceptionCode;
     private final Object[] rejectedValues;

--- a/src/main/java/kr/pickple/back/common/exception/BusinessException.java
+++ b/src/main/java/kr/pickple/back/common/exception/BusinessException.java
@@ -1,0 +1,16 @@
+package kr.pickple.back.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+    private final Object[] rejectedValues;
+
+    protected BusinessException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+        this.rejectedValues = rejectedValues;
+    }
+}

--- a/src/main/java/kr/pickple/back/common/exception/BusinessException.java
+++ b/src/main/java/kr/pickple/back/common/exception/BusinessException.java
@@ -3,7 +3,7 @@ package kr.pickple.back.common.exception;
 import lombok.Getter;
 
 @Getter
-public class BusinessException extends RuntimeException {
+abstract class BusinessException extends RuntimeException {
 
     private final ExceptionCode exceptionCode;
     private final Object[] rejectedValues;

--- a/src/main/java/kr/pickple/back/common/exception/CommonException.java
+++ b/src/main/java/kr/pickple/back/common/exception/CommonException.java
@@ -1,0 +1,8 @@
+package kr.pickple.back.common.exception;
+
+public class CommonException extends BusinessException {
+
+    protected CommonException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
+        super(exceptionCode, rejectedValues);
+    }
+}

--- a/src/main/java/kr/pickple/back/common/exception/CommonExceptionCode.java
+++ b/src/main/java/kr/pickple/back/common/exception/CommonExceptionCode.java
@@ -1,0 +1,21 @@
+package kr.pickple.back.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonExceptionCode implements ExceptionCode {
+
+    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "COM-001", "요청한 URL에 해당하는 리소스를 찾을 수 없음"),
+    COMMON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COM-002", "사용자 입력 유효성 검사 실패"),
+    COMMON_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COM-003", "허용되지 않은 HTTP Method 요청 발생"),
+    COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-004", "기타 서버 내부 에러 발생"),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
+++ b/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
@@ -2,27 +2,11 @@ package kr.pickple.back.common.exception;
 
 import org.springframework.http.HttpStatus;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+public interface ExceptionCode {
 
-@Getter
-@RequiredArgsConstructor
-public enum ExceptionCode {
+    HttpStatus getStatus();
 
-    // Member
+    String getCode();
 
-    // Crew
-
-    // Game
-
-    // Common
-    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "COM-001", "요청한 URL에 해당하는 리소스를 찾을 수 없음"),
-    COMMON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COM-002", "사용자 입력 유효성 검사 실패"),
-    COMMON_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COM-003", "허용되지 않은 HTTP Method 요청 발생"),
-    COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-004", "기타 서버 내부 에러 발생"),
-    ;
-
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+    String getMessage();
 }

--- a/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
+++ b/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
@@ -1,0 +1,28 @@
+package kr.pickple.back.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+
+    // Member
+
+    // Crew
+
+    // Game
+
+    // Common
+    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "COM-001", "요청한 URL에 해당하는 리소스를 찾을 수 없음"),
+    COMMON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COM-002", "사용자 입력 유효성 검사 실패"),
+    COMMON_METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COM-003", "허용되지 않은 HTTP Method 요청 발생"),
+    COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-004", "기타 서버 내부 에러 발생"),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
+++ b/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
@@ -2,7 +2,7 @@ package kr.pickple.back.common.exception;
 
 import org.springframework.http.HttpStatus;
 
-interface ExceptionCode {
+public interface ExceptionCode {
 
     HttpStatus getStatus();
 

--- a/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
+++ b/src/main/java/kr/pickple/back/common/exception/ExceptionCode.java
@@ -2,7 +2,7 @@ package kr.pickple.back.common.exception;
 
 import org.springframework.http.HttpStatus;
 
-public interface ExceptionCode {
+interface ExceptionCode {
 
     HttpStatus getStatus();
 

--- a/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,150 @@
+package kr.pickple.back.common.exception;
+
+import static kr.pickple.back.common.exception.ExceptionCode.*;
+
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import kr.pickple.back.common.dto.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleNoHandlerFoundException(final NoHandlerFoundException e) {
+        log.warn("{}, requestURL: {} ", COMMON_NOT_FOUND.getMessage(), e.getRequestURL(), e);
+
+        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(COMMON_NOT_FOUND.getCode())
+                .message(COMMON_NOT_FOUND.getMessage())
+                .rejectedValues(new String[] {e.getRequestURL()})
+                .build();
+
+        return ResponseEntity.status(COMMON_NOT_FOUND.getStatus())
+                .body(exceptionResponse);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpRequestMethodNotSupportedException(
+            final HttpRequestMethodNotSupportedException e) {
+        log.warn(
+                "{}, supportedHttpMethods: {}, requestMethod: {}",
+                COMMON_METHOD_NOT_ALLOWED.getMessage(),
+                e.getSupportedHttpMethods(),
+                e.getMethod(),
+                e
+        );
+
+        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(COMMON_METHOD_NOT_ALLOWED.getCode())
+                .message(COMMON_METHOD_NOT_ALLOWED.getMessage())
+                .build();
+
+        return ResponseEntity.status(COMMON_METHOD_NOT_ALLOWED.getStatus())
+                .body(exceptionResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(
+            final MethodArgumentNotValidException e) {
+        final List<FieldError> errors = e.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(FieldError.class::cast)
+                .toList();
+
+        log.warn("{}", COMMON_BAD_REQUEST.getMessage(), e);
+        errors.forEach(
+                error -> log.warn("{}, field: {}, rejectedValue: {}",
+                        error.getDefaultMessage(),
+                        error.getField(),
+                        error.getRejectedValue()
+                )
+        );
+
+        final Object[] rejectedValues = errors.stream()
+                .map(FieldError::getRejectedValue)
+                .toArray();
+
+        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(COMMON_BAD_REQUEST.getCode())
+                .message(COMMON_BAD_REQUEST.getMessage())
+                .rejectedValues(rejectedValues)
+                .build();
+
+        return ResponseEntity.badRequest()
+                .body(exceptionResponse);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(
+            final HttpMessageNotReadableException e) {
+        final Throwable cause = e.getCause().getCause();
+
+        // LocalDatetime.parse()가 불가능한 형식으로 datetime 값을 입력받는 경우
+        if (Objects.nonNull(cause) && cause instanceof DateTimeParseException dateTimeParseException) {
+            final String parsedString = dateTimeParseException.getParsedString();
+            log.warn("{}, rejectedValues: {}", COMMON_BAD_REQUEST.getMessage(), parsedString, e);
+
+            final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                    .code(COMMON_BAD_REQUEST.getCode())
+                    .message(COMMON_BAD_REQUEST.getMessage())
+                    .rejectedValues(new String[] {parsedString})
+                    .build();
+
+            return ResponseEntity.badRequest()
+                    .body(exceptionResponse);
+        }
+
+        log.warn("{}", COMMON_BAD_REQUEST.getMessage(), e);
+        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(COMMON_BAD_REQUEST.getCode())
+                .message(COMMON_BAD_REQUEST.getMessage())
+                .build();
+
+        return ResponseEntity.badRequest()
+                .body(exceptionResponse);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ExceptionResponse> handleBusinessException(final BusinessException e) {
+        final ExceptionCode exceptionCode = e.getExceptionCode();
+        final Object[] rejectedValues = e.getRejectedValues();
+
+        log.warn("{}, rejectedValue: {}", exceptionCode.getMessage(), rejectedValues, e);
+
+        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(exceptionCode.getCode())
+                .message(exceptionCode.getMessage())
+                .rejectedValues(rejectedValues)
+                .build();
+
+        return ResponseEntity.status(exceptionCode.getStatus())
+                .body(exceptionResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
+        log.error("{}", COMMON_INTERNAL_SERVER_ERROR.getMessage(), e);
+
+        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(COMMON_INTERNAL_SERVER_ERROR.getCode())
+                .message(COMMON_INTERNAL_SERVER_ERROR.getMessage())
+                .build();
+
+        return ResponseEntity.internalServerError()
+                .body(exceptionResponse);
+    }
+}

--- a/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package kr.pickple.back.common.exception;
 
-import static kr.pickple.back.common.exception.ExceptionCode.*;
+import static kr.pickple.back.common.exception.CommonExceptionCode.*;
 
 import java.time.format.DateTimeParseException;
 import java.util.List;

--- a/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
@@ -38,7 +38,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ExceptionResponse> handleHttpRequestMethodNotSupportedException(
-            final HttpRequestMethodNotSupportedException e) {
+            final HttpRequestMethodNotSupportedException e
+    ) {
         log.warn(
                 "{}, supportedHttpMethods: {}, requestMethod: {}",
                 COMMON_METHOD_NOT_ALLOWED.getMessage(),
@@ -58,7 +59,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(
-            final MethodArgumentNotValidException e) {
+            final MethodArgumentNotValidException e
+    ) {
         final List<FieldError> errors = e.getBindingResult()
                 .getAllErrors()
                 .stream()
@@ -90,7 +92,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(
-            final HttpMessageNotReadableException e) {
+            final HttpMessageNotReadableException e
+    ) {
         final Throwable cause = e.getCause().getCause();
 
         // LocalDatetime.parse()가 불가능한 형식으로 datetime 값을 입력받는 경우

--- a/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/pickple/back/common/exception/GlobalExceptionHandler.java
@@ -26,14 +26,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleNoHandlerFoundException(final NoHandlerFoundException e) {
         log.warn("{}, requestURL: {} ", COMMON_NOT_FOUND.getMessage(), e.getRequestURL(), e);
 
-        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-                .code(COMMON_NOT_FOUND.getCode())
-                .message(COMMON_NOT_FOUND.getMessage())
-                .rejectedValues(new String[] {e.getRequestURL()})
-                .build();
-
         return ResponseEntity.status(COMMON_NOT_FOUND.getStatus())
-                .body(exceptionResponse);
+                .body(ExceptionResponse.from(COMMON_NOT_FOUND.getCode()));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
@@ -48,13 +42,8 @@ public class GlobalExceptionHandler {
                 e
         );
 
-        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-                .code(COMMON_METHOD_NOT_ALLOWED.getCode())
-                .message(COMMON_METHOD_NOT_ALLOWED.getMessage())
-                .build();
-
         return ResponseEntity.status(COMMON_METHOD_NOT_ALLOWED.getStatus())
-                .body(exceptionResponse);
+                .body(ExceptionResponse.from(COMMON_METHOD_NOT_ALLOWED.getCode()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -76,18 +65,8 @@ public class GlobalExceptionHandler {
                 )
         );
 
-        final Object[] rejectedValues = errors.stream()
-                .map(FieldError::getRejectedValue)
-                .toArray();
-
-        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-                .code(COMMON_BAD_REQUEST.getCode())
-                .message(COMMON_BAD_REQUEST.getMessage())
-                .rejectedValues(rejectedValues)
-                .build();
-
         return ResponseEntity.badRequest()
-                .body(exceptionResponse);
+                .body(ExceptionResponse.from(COMMON_BAD_REQUEST.getCode()));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
@@ -101,24 +80,14 @@ public class GlobalExceptionHandler {
             final String parsedString = dateTimeParseException.getParsedString();
             log.warn("{}, rejectedValues: {}", COMMON_BAD_REQUEST.getMessage(), parsedString, e);
 
-            final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-                    .code(COMMON_BAD_REQUEST.getCode())
-                    .message(COMMON_BAD_REQUEST.getMessage())
-                    .rejectedValues(new String[] {parsedString})
-                    .build();
-
             return ResponseEntity.badRequest()
-                    .body(exceptionResponse);
+                    .body(ExceptionResponse.from(COMMON_BAD_REQUEST.getCode()));
         }
 
         log.warn("{}", COMMON_BAD_REQUEST.getMessage(), e);
-        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-                .code(COMMON_BAD_REQUEST.getCode())
-                .message(COMMON_BAD_REQUEST.getMessage())
-                .build();
 
         return ResponseEntity.badRequest()
-                .body(exceptionResponse);
+                .body(ExceptionResponse.from(COMMON_BAD_REQUEST.getCode()));
     }
 
     @ExceptionHandler(BusinessException.class)
@@ -128,26 +97,15 @@ public class GlobalExceptionHandler {
 
         log.warn("{}, rejectedValue: {}", exceptionCode.getMessage(), rejectedValues, e);
 
-        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-                .code(exceptionCode.getCode())
-                .message(exceptionCode.getMessage())
-                .rejectedValues(rejectedValues)
-                .build();
-
         return ResponseEntity.status(exceptionCode.getStatus())
-                .body(exceptionResponse);
+                .body(ExceptionResponse.from(exceptionCode.getCode()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
         log.error("{}", COMMON_INTERNAL_SERVER_ERROR.getMessage(), e);
-
-        final ExceptionResponse exceptionResponse = ExceptionResponse.builder()
-                .code(COMMON_INTERNAL_SERVER_ERROR.getCode())
-                .message(COMMON_INTERNAL_SERVER_ERROR.getMessage())
-                .build();
-
+        
         return ResponseEntity.internalServerError()
-                .body(exceptionResponse);
+                .body(ExceptionResponse.from(COMMON_INTERNAL_SERVER_ERROR.getCode()));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         query.in_clause_parameter_padding: true
+  # 요청 URI로 리소스를 찾을 수 없는 경우 NoHandlerFoundException 예외 발생 시키기
+  mvc:
+    throw-exception-if-no-handler-found: true
+
+  # ResourceHttpRequestHandler에 대한 매핑 끄기
+  web:
+    resources:
+      add-mappings: false


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 전역 예외 처리를 위한 ExceptionHandler를 작성한다.
- Exception을 Custom화 한다.
- Custom Exception을 처리하기 위한 ExceptionCode를 작성한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] ExceptionHandler 구현
    - [X] Custom 예외 계층 구조 잡기
    - [X] ExceptionCode 생성
    - [X] GlobalExceptionHandler 구현

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 프론트엔드분들에게 API 명세서를 전달하여 응답 값에 대한 자료가 명확히 있고 ApiResponse에 들어가는 정보들이 실제로 중복되는 값들이 있고 한 번 더 열어보아야하는 문제들 때문에 ApiResponse를 사용하지 않기로 결정했습니다. 추가적으로 ResponseBodyAdvice를 이용해야하는데 그것을 사용하기 위해 불 필요한 리소스를 투자하는 느낌이었습니다.
- Custom 예외 계층을 RuntimeException > BusinessException > 주로 사용되는 Exception(NotFoundException) > 도메인 계층 Exception(MemberException)으로 구분해보려하였으나 구분했을 때 중복되는 하위 Exception이 생기고 ExceptionCode를 사용하는 의미가 퇴색될 것 같아 RuntimeException > BusinessException > 도메인 계층 Exception(MemberException) 형태를 채택했습니다.
- ExceptionCode에 code 부분을 추가하였고, 이 부분에 대한 설명은 노션 문서에 정리해두었습니다!(꼭 참고해주세요!)
- log의 기준은 개발자가 발견해내지 못한 예외는 error, 개발자가 발견해낸 예외는 warn으로 처리했습니다!

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
