### PR TITLE
[#24] 포지션 목록 조회 기능 구현

### DIFF
--- a/src/main/http/position/position.http
+++ b/src/main/http/position/position.http
@@ -1,0 +1,2 @@
+### 포지션 목록 조회
+GET http://localhost:8080/positions

--- a/src/main/java/kr/pickple/back/position/controller/PositionController.java
+++ b/src/main/java/kr/pickple/back/position/controller/PositionController.java
@@ -1,13 +1,11 @@
 package kr.pickple.back.position.controller;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import kr.pickple.back.position.domain.Position;
 import kr.pickple.back.position.dto.PositionResponse;
 import kr.pickple.back.position.service.PositionService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/positions")
 @RequiredArgsConstructor
 public class PositionController {
+
     private final PositionService positionService;
 
     @GetMapping

--- a/src/main/java/kr/pickple/back/position/controller/PositionController.java
+++ b/src/main/java/kr/pickple/back/position/controller/PositionController.java
@@ -1,0 +1,25 @@
+package kr.pickple.back.position.controller;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.pickple.back.position.domain.Position;
+import kr.pickple.back.position.dto.PositionResponse;
+import kr.pickple.back.position.service.PositionService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/positions")
+@RequiredArgsConstructor
+public class PositionController {
+    private final PositionService positionService;
+
+    @GetMapping
+    public List<PositionResponse> findAllPositions() {
+        return positionService.findAllPositions();
+    }
+}

--- a/src/main/java/kr/pickple/back/position/controller/PositionController.java
+++ b/src/main/java/kr/pickple/back/position/controller/PositionController.java
@@ -1,7 +1,10 @@
 package kr.pickple.back.position.controller;
 
+import static org.springframework.http.HttpStatus.*;
+
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +21,8 @@ public class PositionController {
     private final PositionService positionService;
 
     @GetMapping
-    public List<PositionResponse> findAllPositions() {
-        return positionService.findAllPositions();
+    public ResponseEntity<List<PositionResponse>> findAllPositions() {
+        return ResponseEntity.status(OK)
+                .body(positionService.findAllPositions());
     }
 }

--- a/src/main/java/kr/pickple/back/position/domain/Position.java
+++ b/src/main/java/kr/pickple/back/position/domain/Position.java
@@ -45,5 +45,4 @@ public enum Position {
 
         throw new PositionException(POSITION_NOT_FOUND, positionAcronym);
     }
-
 }

--- a/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
+++ b/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
@@ -10,13 +10,13 @@ public class PositionResponse {
     private String acronym;
     private String description;
 
-    private PositionResponse(Position position) {
+    private PositionResponse(final Position position) {
         this.name = position.getName();
         this.description = position.getDescription();
         this.acronym = position.getAcronym();
     }
 
-    public static PositionResponse from(Position position) {
+    public static PositionResponse from(final Position position) {
         return new PositionResponse(position);
     }
 }

--- a/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
+++ b/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
@@ -1,22 +1,25 @@
 package kr.pickple.back.position.dto;
 
 import kr.pickple.back.position.domain.Position;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PositionResponse {
 
     private String name;
     private String acronym;
     private String description;
 
-    private PositionResponse(final Position position) {
-        this.name = position.getName();
-        this.description = position.getDescription();
-        this.acronym = position.getAcronym();
-    }
-
     public static PositionResponse from(final Position position) {
-        return new PositionResponse(position);
+        return PositionResponse.builder()
+                .name(position.getName())
+                .acronym(position.getAcronym())
+                .description(position.getDescription())
+                .build();
     }
 }

--- a/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
+++ b/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
@@ -1,0 +1,25 @@
+package kr.pickple.back.position.dto;
+
+import kr.pickple.back.position.domain.Position;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PositionResponse {
+
+    private String name;
+    private String acronym;
+    private String description;
+
+    private PositionResponse(Position position) {
+        this.name = position.getName();
+        this.description = position.getDescription();
+        this.acronym = position.getAcronym();
+    }
+
+    public static PositionResponse from(Position position) {
+        return new PositionResponse(position);
+    }
+}

--- a/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
+++ b/src/main/java/kr/pickple/back/position/dto/PositionResponse.java
@@ -1,12 +1,9 @@
 package kr.pickple.back.position.dto;
 
 import kr.pickple.back.position.domain.Position;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PositionResponse {
 
     private String name;

--- a/src/main/java/kr/pickple/back/position/service/PositionService.java
+++ b/src/main/java/kr/pickple/back/position/service/PositionService.java
@@ -12,10 +12,7 @@ import kr.pickple.back.position.dto.PositionResponse;
 public class PositionService {
 
     public List<PositionResponse> findAllPositions() {
-        final List<Position> positions = Arrays.stream(Position.values())
-                .toList();
-
-        return positions.stream()
+        return Arrays.stream(Position.values())
                 .map(PositionResponse::from)
                 .toList();
     }

--- a/src/main/java/kr/pickple/back/position/service/PositionService.java
+++ b/src/main/java/kr/pickple/back/position/service/PositionService.java
@@ -12,7 +12,8 @@ import kr.pickple.back.position.dto.PositionResponse;
 public class PositionService {
 
     public List<PositionResponse> findAllPositions() {
-        final List<Position> positions = Arrays.stream(Position.values()).toList();
+        final List<Position> positions = Arrays.stream(Position.values())
+                .toList();
 
         return positions.stream()
                 .map(PositionResponse::from)

--- a/src/main/java/kr/pickple/back/position/service/PositionService.java
+++ b/src/main/java/kr/pickple/back/position/service/PositionService.java
@@ -10,6 +10,7 @@ import kr.pickple.back.position.dto.PositionResponse;
 
 @Service
 public class PositionService {
+    
     public List<PositionResponse> findAllPositions() {
         List<Position> positions = Arrays.stream(Position.values()).toList();
 

--- a/src/main/java/kr/pickple/back/position/service/PositionService.java
+++ b/src/main/java/kr/pickple/back/position/service/PositionService.java
@@ -1,0 +1,20 @@
+package kr.pickple.back.position.service;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import kr.pickple.back.position.domain.Position;
+import kr.pickple.back.position.dto.PositionResponse;
+
+@Service
+public class PositionService {
+    public List<PositionResponse> findAllPositions() {
+        List<Position> positions = Arrays.stream(Position.values()).toList();
+
+        return positions.stream()
+                .map(PositionResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/kr/pickple/back/position/service/PositionService.java
+++ b/src/main/java/kr/pickple/back/position/service/PositionService.java
@@ -10,9 +10,9 @@ import kr.pickple.back.position.dto.PositionResponse;
 
 @Service
 public class PositionService {
-    
+
     public List<PositionResponse> findAllPositions() {
-        List<Position> positions = Arrays.stream(Position.values()).toList();
+        final List<Position> positions = Arrays.stream(Position.values()).toList();
 
         return positions.stream()
                 .map(PositionResponse::from)

--- a/src/test/java/kr/pickple/back/position/service/PositionServiceTest.java
+++ b/src/test/java/kr/pickple/back/position/service/PositionServiceTest.java
@@ -1,0 +1,52 @@
+package kr.pickple.back.position.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import kr.pickple.back.position.domain.Position;
+import kr.pickple.back.position.dto.PositionResponse;
+
+@SpringBootTest
+class PositionServiceTest {
+
+    @Autowired
+    private PositionService positionService;
+
+    @Test
+    @DisplayName("포지션 정보 조회 시, 전체 포지션 정보를 반환한다.")
+    void findAllPositions_Success() {
+        //when
+        List<PositionResponse> Positions = positionService.findAllPositions();
+
+        //then
+        assertThat(Positions.get(0).getName()).isEqualTo(Position.CENTER.getName());
+        assertThat(Positions.get(0).getAcronym()).isEqualTo(Position.CENTER.getAcronym());
+        assertThat(Positions.get(0).getDescription()).isEqualTo(Position.CENTER.getDescription());
+
+        assertThat(Positions.get(1).getName()).isEqualTo(Position.POWER_FORWARD.getName());
+        assertThat(Positions.get(1).getAcronym()).isEqualTo(Position.POWER_FORWARD.getAcronym());
+        assertThat(Positions.get(1).getDescription()).isEqualTo(Position.POWER_FORWARD.getDescription());
+
+        assertThat(Positions.get(2).getName()).isEqualTo(Position.SMALL_FORWARD.getName());
+        assertThat(Positions.get(2).getAcronym()).isEqualTo(Position.SMALL_FORWARD.getAcronym());
+        assertThat(Positions.get(2).getDescription()).isEqualTo(Position.SMALL_FORWARD.getDescription());
+
+        assertThat(Positions.get(3).getName()).isEqualTo(Position.POINT_GUARD.getName());
+        assertThat(Positions.get(3).getAcronym()).isEqualTo(Position.POINT_GUARD.getAcronym());
+        assertThat(Positions.get(3).getDescription()).isEqualTo(Position.POINT_GUARD.getDescription());
+
+        assertThat(Positions.get(4).getName()).isEqualTo(Position.SHOOTING_GUARD.getName());
+        assertThat(Positions.get(4).getAcronym()).isEqualTo(Position.SHOOTING_GUARD.getAcronym());
+        assertThat(Positions.get(4).getDescription()).isEqualTo(Position.SHOOTING_GUARD.getDescription());
+
+        assertThat(Positions.get(5).getName()).isEqualTo(Position.EMPTY.getName());
+        assertThat(Positions.get(5).getAcronym()).isEqualTo(Position.EMPTY.getAcronym());
+        assertThat(Positions.get(5).getDescription()).isEqualTo(Position.EMPTY.getDescription());
+    }
+}


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
각 포지션의 [이름, 축약어, 설명]을 한 번에 조회할 수 있는 api를 구현했습니다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 포지션 목록 조회 기능 구현
- [x] 포지션 목록 조회 테스트 구현

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- Postion enum 값을 직렬화 할 때 @JsonValue 어노테이션을 활용하자는 의논이 있었으나, 다른 방식으로 구현했습니다. enum에 속한 필드 하나를 직렬화하는 상황이 아닌, 모든 필드를 직렬화하는 상황이기에, 특정 필드만 @JsonValue로 지정할 수 없었습니다. 따라서 dto가 enum타입 대신 enum 내부의 속성 필드들을 모두 가지게 하여 처리했습니다.

---

### 기타
<!-- 작성하지 않으면 삭제 -->

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
