### PR TITLE
[#38] 사용자 프로필 조회 기능 추가

### DIFF
--- a/src/main/http/member/member.http
+++ b/src/main/http/member/member.http
@@ -12,3 +12,6 @@ Content-Type: application/json
 	"oauthId": 32014123,
 	"oauthProvider": "KAKAO"
 }
+
+### 사용자 프로필 조회
+GET http://localhost:8080/members/1

--- a/src/main/java/kr/pickple/back/crew/dto/response/CrewResponse.java
+++ b/src/main/java/kr/pickple/back/crew/dto/response/CrewResponse.java
@@ -1,0 +1,23 @@
+package kr.pickple.back.crew.dto.response;
+
+import kr.pickple.back.crew.domain.CrewStatus;
+import kr.pickple.back.member.dto.response.MemberResponse;
+import lombok.Getter;
+
+@Getter
+public class CrewResponse {
+
+    private Long id;
+    private String name;
+    private String content;
+    private Integer memberCount;
+    private String profileImageUrl;
+    private String backgroundImageUrl;
+    private CrewStatus status;
+    private Integer likeCount;
+    private Integer maxMemberCount;
+    private Integer competitionPoint;
+    private MemberResponse leader;
+    private String addressDepth1;
+    private String addressDepth2;
+}

--- a/src/main/java/kr/pickple/back/member/controller/MemberController.java
+++ b/src/main/java/kr/pickple/back/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package kr.pickple.back.member.controller;
 import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import kr.pickple.back.member.dto.request.MemberCreateRequest;
 import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
+import kr.pickple.back.member.dto.response.MemberProfileResponse;
 import kr.pickple.back.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 
@@ -27,5 +30,11 @@ public class MemberController {
     ) {
         return ResponseEntity.status(CREATED)
                 .body(memberService.createMember(memberCreateRequest));
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberProfileResponse> findMemberProfileById(@PathVariable Long memberId) {
+        return ResponseEntity.status(OK)
+                .body(memberService.findMemberProfileById(memberId));
     }
 }

--- a/src/main/java/kr/pickple/back/member/domain/MemberPosition.java
+++ b/src/main/java/kr/pickple/back/member/domain/MemberPosition.java
@@ -15,6 +15,7 @@ import kr.pickple.back.position.domain.Position;
 import kr.pickple.back.position.util.PositionStatusConverter;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -25,6 +26,7 @@ public class MemberPosition extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Getter
     @NotNull
     @Convert(converter = PositionStatusConverter.class)
     @Column(length = 2)

--- a/src/main/java/kr/pickple/back/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/kr/pickple/back/member/dto/response/MemberProfileResponse.java
@@ -1,0 +1,44 @@
+package kr.pickple.back.member.dto.response;
+
+import java.util.List;
+
+import kr.pickple.back.crew.dto.response.CrewResponse;
+import kr.pickple.back.member.domain.Member;
+import kr.pickple.back.position.domain.Position;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberProfileResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String introduction;
+    private String profileImageUrl;
+    private Integer mannerScore;
+    private Integer mannerScoreCount;
+    private String addressDepth1;
+    private String addressDepth2;
+    private List<Position> positions;
+    private List<CrewResponse> crews; //TODO: 추후 Crew 도메인 완성 시, 해당 필드에 대한 로직 추가 예정 (10.31 김영주)
+
+    public static MemberProfileResponse of(final Member member, final List<Position> positions) {
+        return MemberProfileResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .profileImageUrl(member.getProfileImageUrl())
+                .mannerScore(member.getMannerScore())
+                .mannerScoreCount(member.getMannerScoreCount())
+                .addressDepth1(member.getAddressDepth1().getName())
+                .addressDepth2(member.getAddressDepth2().getName())
+                .positions(positions)
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/member/dto/response/MemberResponse.java
+++ b/src/main/java/kr/pickple/back/member/dto/response/MemberResponse.java
@@ -1,0 +1,21 @@
+package kr.pickple.back.member.dto.response;
+
+import java.util.List;
+
+import kr.pickple.back.position.domain.Position;
+import lombok.Getter;
+
+@Getter
+public class MemberResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String introduction;
+    private String profileImageUrl;
+    private Integer mannerScore;
+    private Integer mannerScoreCount;
+    private String addressDepth1;
+    private String addressDepth2;
+    private List<Position> positions;
+}

--- a/src/main/java/kr/pickple/back/member/repository/MemberPositionRepository.java
+++ b/src/main/java/kr/pickple/back/member/repository/MemberPositionRepository.java
@@ -1,9 +1,13 @@
 package kr.pickple.back.member.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.domain.MemberPosition;
 
 public interface MemberPositionRepository extends JpaRepository<MemberPosition, Long> {
 
+    List<MemberPosition> findAllByMember(final Member member);
 }

--- a/src/main/java/kr/pickple/back/member/service/MemberService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberService.java
@@ -13,6 +13,7 @@ import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.domain.MemberPosition;
 import kr.pickple.back.member.dto.request.MemberCreateRequest;
 import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
+import kr.pickple.back.member.dto.response.MemberProfileResponse;
 import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberPositionRepository;
 import kr.pickple.back.member.repository.MemberRepository;
@@ -62,5 +63,17 @@ public class MemberService {
         if (memberRepository.existsByEmailOrNicknameOrOauthId(email, nickname, oauthId)) {
             throw new MemberException(MEMBER_IS_EXISTED, email, nickname, oauthId);
         }
+    }
+
+    public MemberProfileResponse findMemberProfileById(final Long memberId) {
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND, memberId));
+
+        final List<Position> positions = memberPositionRepository.findAllByMember(member)
+                .stream()
+                .map(MemberPosition::getPosition)
+                .toList();
+
+        return MemberProfileResponse.of(member, positions);
     }
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 사용자 프로필 조회 기능을 추가한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 사용자 프로필 조회 기능 추가
- [x] 테스트 코드 작성

---

<!-- 이슈와 관련된 데이터를 나열 -->
### 📀 관련 데이터 (화면, 테이블, API 등)
#### 화면
![image](https://github.com/Java-and-Script/pickple-back/assets/49775540/df9427a9-1112-4ed8-8323-368b0ce692a5)


#### 테이블 명
- member
- member_position


#### API endpoint
- GET /members/{memberId}

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
