### PR TITLE
[#46] OAuth와 회원가입, 로그인 기능 연동(accessToken, refreshToken, registerToken 발급)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,51 +1,51 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.5'
-	id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.5'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 group = 'kr.pickple'
 version = '0.0.1'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	implementation group: 'org.flywaydb', name: 'flyway-mysql', version: '9.10.2'
+    implementation group: 'org.flywaydb', name: 'flyway-mysql', version: '9.10.2'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.1'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.1'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.1'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.1'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.1'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.1'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 tasks.named('compileJava') {
@@ -53,19 +53,19 @@ tasks.named('compileJava') {
 }
 
 task copySubmodule(type: Copy) {
-	copy {
-		from './secret'
-		include "application*.yml"
-		into 'src/main/resources'
-	}
+    copy {
+        from './secret'
+        include "application*.yml"
+        into 'src/main/resources'
+    }
 
-	copy {
-		from './secret'
-		include "docker-compose.yml"
-		into 'deploy/dev'
-	}
+    copy {
+        from './secret'
+        include "docker-compose.yml"
+        into 'deploy/dev'
+    }
 }
 
 jar {
-	enabled = false
+    enabled = false
 }

--- a/src/main/java/kr/pickple/back/auth/domain/oauth/OauthMember.java
+++ b/src/main/java/kr/pickple/back/auth/domain/oauth/OauthMember.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OauthMember {
 
-    private Long id;
+    private Long oauthId;
     private String email;
     private String profileImageUrl;
     private String nickname;

--- a/src/main/java/kr/pickple/back/auth/domain/token/AuthTokens.java
+++ b/src/main/java/kr/pickple/back/auth/domain/token/AuthTokens.java
@@ -1,15 +1,15 @@
 package kr.pickple.back.auth.domain.token;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthTokens {
 
-    private final String accessToken;
-    private final String refreshToken;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/kr/pickple/back/auth/domain/token/JwtProvider.java
+++ b/src/main/java/kr/pickple/back/auth/domain/token/JwtProvider.java
@@ -40,8 +40,12 @@ public class JwtProvider {
                 .build();
     }
 
-    public String createRegisterToken(final String subject) {
-        return generateToken(subject, jwtProperties.getRegisterTokenExpirationTime());
+    public AuthTokens createRegisterToken(final String subject) {
+        String registerToken = generateToken(subject, jwtProperties.getRegisterTokenExpirationTime());
+
+        return AuthTokens.builder()
+                .accessToken(registerToken)
+                .build();
     }
 
     private String generateToken(final String subject, final Long expirationTime) {

--- a/src/main/java/kr/pickple/back/auth/domain/token/RefreshToken.java
+++ b/src/main/java/kr/pickple/back/auth/domain/token/RefreshToken.java
@@ -1,0 +1,22 @@
+package kr.pickple.back.auth.domain.token;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshToken {
+
+    @Id
+    private String token;
+
+    @NotNull
+    private Long memberId;
+}

--- a/src/main/java/kr/pickple/back/auth/dto/kakao/KakaoMemberResponse.java
+++ b/src/main/java/kr/pickple/back/auth/dto/kakao/KakaoMemberResponse.java
@@ -15,7 +15,7 @@ public class KakaoMemberResponse {
 
     public OauthMember toOauthMember() {
         return OauthMember.builder()
-                .id(id)
+                .oauthId(id)
                 .email(kakaoAccount.email)
                 .nickname(kakaoAccount.profile.nickname)
                 .profileImageUrl(kakaoAccount.profile.profileImageUrl)

--- a/src/main/java/kr/pickple/back/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/pickple/back/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package kr.pickple.back.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.pickple.back.auth.domain.token.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+
+}

--- a/src/main/java/kr/pickple/back/auth/service/OauthService.java
+++ b/src/main/java/kr/pickple/back/auth/service/OauthService.java
@@ -1,24 +1,62 @@
 package kr.pickple.back.auth.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
+import kr.pickple.back.auth.domain.oauth.OauthMember;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
+import kr.pickple.back.auth.domain.token.AuthTokens;
+import kr.pickple.back.auth.domain.token.JwtProvider;
+import kr.pickple.back.auth.domain.token.RefreshToken;
+import kr.pickple.back.auth.repository.RefreshTokenRepository;
 import kr.pickple.back.auth.service.authcode.AuthCodeRequestUrlProviderComposite;
 import kr.pickple.back.auth.service.memberclient.OauthMemberClientComposite;
+import kr.pickple.back.member.domain.Member;
+import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
+import kr.pickple.back.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class OauthService {
 
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
     private final OauthMemberClientComposite oauthMemberClientComposite;
+    private final JwtProvider jwtProvider;
 
     public String getAuthCodeRequestUrl(final OauthProvider oauthProvider) {
         return authCodeRequestUrlProviderComposite.provide(oauthProvider);
     }
 
-    public void processLoginOrRegistration(final OauthProvider oauthProvider, final String authCode) {
-        oauthMemberClientComposite.fetch(oauthProvider, authCode);
+    public AuthenticatedMemberResponse processLoginOrRegistration(
+            final OauthProvider oauthProvider,
+            final String authCode
+    ) {
+        final OauthMember oauthMember = oauthMemberClientComposite.fetch(oauthProvider, authCode);
+        final Optional<Member> member = memberRepository.findByOauthId(oauthMember.getOauthId());
+
+        // 사용자가 로그인 하는 경우
+        if (member.isPresent()) {
+            final Member loginMember = member.get();
+            final AuthTokens loginTokens = jwtProvider.createLoginToken(String.valueOf(loginMember.getId()));
+
+            final RefreshToken refreshToken = RefreshToken.builder()
+                    .token(loginTokens.getRefreshToken())
+                    .memberId(loginMember.getId())
+                    .build();
+
+            refreshTokenRepository.save(refreshToken);
+
+            return AuthenticatedMemberResponse.of(loginMember, loginTokens);
+        }
+
+        // 사용자가 회원 가입 시, 추가 정보(주 활동지역, 포지션)를 입력하는 경우
+        final String oauthProviderName = oauthMember.getOauthProvider().name();
+        final AuthTokens registerToken = jwtProvider.createRegisterToken(oauthProviderName + oauthMember.getOauthId());
+
+        return AuthenticatedMemberResponse.of(oauthMember, registerToken);
     }
 }

--- a/src/main/java/kr/pickple/back/member/controller/MemberController.java
+++ b/src/main/java/kr/pickple/back/member/controller/MemberController.java
@@ -1,7 +1,9 @@
 package kr.pickple.back.member.controller;
 
+import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpStatus.*;
 
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,7 +12,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import kr.pickple.back.auth.config.property.JwtProperties;
 import kr.pickple.back.member.dto.request.MemberCreateRequest;
 import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
 import kr.pickple.back.member.dto.response.MemberProfileResponse;
@@ -23,13 +27,30 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
     private final MemberService memberService;
+    private final JwtProperties jwtProperties;
 
     @PostMapping
     public ResponseEntity<AuthenticatedMemberResponse> createMember(
-            @Valid @RequestBody MemberCreateRequest memberCreateRequest
+            @Valid @RequestBody MemberCreateRequest memberCreateRequest,
+            final HttpServletResponse httpServletResponse
     ) {
+        final AuthenticatedMemberResponse authenticatedMemberResponse = memberService.createMember(memberCreateRequest);
+        final String refreshToken = authenticatedMemberResponse.getRefreshToken();
+
+        if (refreshToken != null) {
+            final ResponseCookie cookie = ResponseCookie.from("refresh-token", refreshToken)
+                    .maxAge(jwtProperties.getRefreshTokenExpirationTime())
+                    .sameSite("None")
+                    .secure(true)
+                    .httpOnly(true)
+                    .path("/")
+                    .build();
+
+            httpServletResponse.addHeader(SET_COOKIE, cookie.toString());
+        }
+
         return ResponseEntity.status(CREATED)
-                .body(memberService.createMember(memberCreateRequest));
+                .body(authenticatedMemberResponse);
     }
 
     @GetMapping("/{memberId}")

--- a/src/main/java/kr/pickple/back/member/dto/response/AuthenticatedMemberResponse.java
+++ b/src/main/java/kr/pickple/back/member/dto/response/AuthenticatedMemberResponse.java
@@ -1,6 +1,8 @@
 package kr.pickple.back.member.dto.response;
 
+import kr.pickple.back.auth.domain.oauth.OauthMember;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
+import kr.pickple.back.auth.domain.token.AuthTokens;
 import kr.pickple.back.member.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,17 +10,21 @@ import lombok.Getter;
 @Getter
 public class AuthenticatedMemberResponse {
 
-    private Long id;
-    private String nickname;
-    private String profileImageUrl;
-    private String email;
-    private Long oauthId;
-    private OauthProvider oauthProvider;
-    private String addressDepth1;
-    private String addressDepth2;
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long id;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final String email;
+    private final Long oauthId;
+    private final OauthProvider oauthProvider;
+    private final String addressDepth1;
+    private final String addressDepth2;
 
     @Builder
     private AuthenticatedMemberResponse(
+            final String accessToken,
+            final String refreshToken,
             final Long id,
             final String nickname,
             final String profileImageUrl,
@@ -28,6 +34,8 @@ public class AuthenticatedMemberResponse {
             final String addressDepth1,
             final String addressDepth2
     ) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
         this.id = id;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
@@ -38,8 +46,10 @@ public class AuthenticatedMemberResponse {
         this.addressDepth2 = addressDepth2;
     }
 
-    public static AuthenticatedMemberResponse from(final Member member) {
+    public static AuthenticatedMemberResponse of(final Member member, final AuthTokens authTokens) {
         return AuthenticatedMemberResponse.builder()
+                .accessToken(authTokens.getAccessToken())
+                .refreshToken(authTokens.getRefreshToken())
                 .id(member.getId())
                 .nickname(member.getNickname())
                 .profileImageUrl(member.getProfileImageUrl())
@@ -48,6 +58,17 @@ public class AuthenticatedMemberResponse {
                 .oauthProvider(member.getOauthProvider())
                 .addressDepth1(member.getAddressDepth1().getName())
                 .addressDepth2(member.getAddressDepth2().getName())
+                .build();
+    }
+
+    public static AuthenticatedMemberResponse of(final OauthMember oauthMember, final AuthTokens registerToken) {
+        return AuthenticatedMemberResponse.builder()
+                .accessToken(registerToken.getAccessToken())
+                .nickname(oauthMember.getNickname())
+                .profileImageUrl(oauthMember.getProfileImageUrl())
+                .email(oauthMember.getEmail())
+                .oauthId(oauthMember.getOauthId())
+                .oauthProvider(oauthMember.getOauthProvider())
                 .build();
     }
 }

--- a/src/main/java/kr/pickple/back/member/repository/MemberRepository.java
+++ b/src/main/java/kr/pickple/back/member/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package kr.pickple.back.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.pickple.back.member.domain.Member;
@@ -7,4 +9,6 @@ import kr.pickple.back.member.domain.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Boolean existsByEmailOrNicknameOrOauthId(final String email, final String nickname, final Long oauthId);
+
+    Optional<Member> findByOauthId(final Long oauthId);
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항
@Hchanghyeon 창현님과 페어프로그래밍으로 진행했습니다~

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- OAuth를 이용해 로그인 및 회원가입 시, accessToken, refreshToken을 발급한다.
- OAuth를 이용해 인증 후, 회원 정보 추가를 위한 registerToken을 발급한다.
- 발급된 토큰과 Kakao 사용자 정보를 클라이언트에게 전달한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 회원 Id를 이용한 accessToken 발급
- [x] refreshToken 발급 및 DB 테이블에 저장
- [x] 회원 가입 시 추가 정보 입력을 위한 registerToken 발급
- [x] 토큰 및 사용자 정보 클라이언트에게 전달하도록 DTO 반환

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
