### PR TITLE
[#50] API 요청에 대한 인증, 인가 기능 구현

### DIFF
--- a/src/main/java/kr/pickple/back/auth/config/OauthProviderConverter.java
+++ b/src/main/java/kr/pickple/back/auth/config/OauthProviderConverter.java
@@ -1,4 +1,4 @@
-package kr.pickple.back.auth.util;
+package kr.pickple.back.auth.config;
 
 import org.springframework.core.convert.converter.Converter;
 

--- a/src/main/java/kr/pickple/back/auth/config/resolver/Login.java
+++ b/src/main/java/kr/pickple/back/auth/config/resolver/Login.java
@@ -1,0 +1,12 @@
+package kr.pickple.back.auth.config.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+
+}

--- a/src/main/java/kr/pickple/back/auth/config/resolver/LoginTokenArgumentResolver.java
+++ b/src/main/java/kr/pickple/back/auth/config/resolver/LoginTokenArgumentResolver.java
@@ -1,0 +1,53 @@
+package kr.pickple.back.auth.config.resolver;
+
+import static org.springframework.http.HttpHeaders.*;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.pickple.back.auth.domain.token.AuthTokens;
+import kr.pickple.back.auth.domain.token.JwtProvider;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginTokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+    private final TokenExtractor tokenExtractor;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.withContainingClass(Long.class)
+                .hasParameterAnnotation(Login.class);
+    }
+
+    @Override
+    public Long resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        final Cookie[] cookies = webRequest.getNativeRequest(HttpServletRequest.class)
+                .getCookies();
+
+        final String accessToken = tokenExtractor.extractAccessToken(webRequest.getHeader(AUTHORIZATION));
+        final String refreshToken = tokenExtractor.extractRefreshToken(cookies);
+
+        final AuthTokens authTokens = AuthTokens.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        jwtProvider.validateTokens(authTokens);
+
+        return Long.parseLong(jwtProvider.getSubject(accessToken));
+    }
+}

--- a/src/main/java/kr/pickple/back/auth/config/resolver/RegisterTokenArgumentResolver.java
+++ b/src/main/java/kr/pickple/back/auth/config/resolver/RegisterTokenArgumentResolver.java
@@ -1,0 +1,40 @@
+package kr.pickple.back.auth.config.resolver;
+
+import static org.springframework.http.HttpHeaders.*;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import kr.pickple.back.auth.domain.token.JwtProvider;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RegisterTokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+    private final TokenExtractor tokenExtractor;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.withContainingClass(String.class)
+                .hasParameterAnnotation(SignUp.class);
+    }
+
+    @Override
+    public String resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        final String registerToken = tokenExtractor.extractRegisterToken(webRequest.getHeader(AUTHORIZATION));
+        jwtProvider.validateRegisterToken(registerToken);
+
+        return jwtProvider.getSubject(registerToken);
+    }
+}

--- a/src/main/java/kr/pickple/back/auth/config/resolver/SignUp.java
+++ b/src/main/java/kr/pickple/back/auth/config/resolver/SignUp.java
@@ -1,0 +1,12 @@
+package kr.pickple.back.auth.config.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SignUp {
+
+}

--- a/src/main/java/kr/pickple/back/auth/config/resolver/TokenExtractor.java
+++ b/src/main/java/kr/pickple/back/auth/config/resolver/TokenExtractor.java
@@ -1,0 +1,54 @@
+package kr.pickple.back.auth.config.resolver;
+
+import static kr.pickple.back.auth.exception.AuthExceptionCode.*;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+import kr.pickple.back.auth.exception.AuthException;
+import kr.pickple.back.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TokenExtractor {
+
+    private static final String BEARER_TYPE = "Bearer ";
+    private static final String REFRESH_TOKEN = "refresh-token";
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String extractRegisterToken(final String header) {
+        if (header != null && header.startsWith(BEARER_TYPE)) {
+            return header.substring(BEARER_TYPE.length()).trim();
+        }
+
+        throw new AuthException(AUTH_INVALID_REGISTER_TOKEN, header);
+    }
+
+    public String extractAccessToken(final String header) {
+        if (header != null && header.startsWith(BEARER_TYPE)) {
+            return header.substring(BEARER_TYPE.length()).trim();
+        }
+
+        throw new AuthException(AUTH_INVALID_ACCESS_TOKEN, header);
+    }
+
+    public String extractRefreshToken(final Cookie... cookies) {
+        if (cookies == null) {
+            throw new AuthException(AUTH_NOT_FOUND_REFRESH_TOKEN);
+        }
+
+        return Arrays.stream(cookies)
+                .filter(this::isValidRefreshToken)
+                .findFirst()
+                .orElseThrow(() -> new AuthException(AUTH_NOT_FOUND_REFRESH_TOKEN))
+                .getValue();
+    }
+
+    private Boolean isValidRefreshToken(final Cookie cookie) {
+        return REFRESH_TOKEN.equals(cookie.getName()) && refreshTokenRepository.existsById(cookie.getValue());
+    }
+}

--- a/src/main/java/kr/pickple/back/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/pickple/back/auth/exception/AuthExceptionCode.java
@@ -17,6 +17,7 @@ public enum AuthExceptionCode implements ExceptionCode {
     AUTH_INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AUT-005", "유효하지 않은 AccessToken"),
     AUTH_INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUT-006", "유효하지 않은 RefreshToken"),
     AUTH_INVALID_REGISTER_TOKEN(HttpStatus.BAD_REQUEST, "AUT-007", "유효하지 않은 RegisterToken"),
+    AUTH_NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "AUT-008", "RefreshToken이 존재하지 않음"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/pickple/back/auth/service/OauthService.java
+++ b/src/main/java/kr/pickple/back/auth/service/OauthService.java
@@ -3,6 +3,7 @@ package kr.pickple.back.auth.service;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import kr.pickple.back.auth.domain.oauth.OauthMember;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OauthService {
 
     private final MemberRepository memberRepository;
@@ -31,6 +33,7 @@ public class OauthService {
         return authCodeRequestUrlProviderComposite.provide(oauthProvider);
     }
 
+    @Transactional
     public AuthenticatedMemberResponse processLoginOrRegistration(
             final OauthProvider oauthProvider,
             final String authCode

--- a/src/main/java/kr/pickple/back/common/config/WebConfig.java
+++ b/src/main/java/kr/pickple/back/common/config/WebConfig.java
@@ -1,13 +1,18 @@
 package kr.pickple.back.common.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import kr.pickple.back.auth.config.OauthProviderConverter;
 import kr.pickple.back.auth.config.property.CorsProperties;
-import kr.pickple.back.auth.util.OauthProviderConverter;
+import kr.pickple.back.auth.config.resolver.LoginTokenArgumentResolver;
+import kr.pickple.back.auth.config.resolver.RegisterTokenArgumentResolver;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -15,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 public class WebConfig implements WebMvcConfigurer {
 
     private final CorsProperties corsProperties;
+    private final RegisterTokenArgumentResolver registerTokenArgumentResolver;
+    private final LoginTokenArgumentResolver loginTokenArgumentResolver;
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
@@ -34,5 +41,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(final FormatterRegistry registry) {
         registry.addConverter(new OauthProviderConverter());
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(registerTokenArgumentResolver);
+        resolvers.add(loginTokenArgumentResolver);
     }
 }

--- a/src/main/java/kr/pickple/back/member/exception/MemberExceptionCode.java
+++ b/src/main/java/kr/pickple/back/member/exception/MemberExceptionCode.java
@@ -12,7 +12,10 @@ public enum MemberExceptionCode implements ExceptionCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM-001", "사용자를 찾을 수 없음"),
     MEMBER_IS_EXISTED(HttpStatus.BAD_REQUEST, "MEM-002", "이미 존재하는 사용자 정보"),
-    MEMBER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM-003", "사용자 상태는 활동이거나 탈퇴만 가능");
+    MEMBER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM-003", "사용자 상태는 활동이거나 탈퇴만 가능"),
+    MEMBER_SIGNUP_OAUTH_SUBJECT_INVALID(HttpStatus.BAD_REQUEST, "MEM-004",
+            "회원 가입 시, 사용자의 OAuth ID와 Provider의 정보가 유효하지 않음"),
+    ;
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 👨‍💻 작업 사항
@Hchanghyeon 창현님과 페어프로그래밍으로 진행하였습니다~

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 접근 권한이 필요한 API 요청 시, accessToken, refreshToken, registerToken을 검증하는 로직을 작성한다.
- 이에 따라 각 요청에 커스텀 어노테이션을 부여하여 인증, 인가 로직을 완성한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] RegisterTokenArgumentResolver 등록 및 커스텀 어노테이션 생성
  - 클라이언트가 보낸 registerToken을 검증한다.
  - SignUp 어노테이션을 이용해 subject(string) 값을 받는다.
- [x] LoginTokenArgumentResolver 등록 및 커스텀 어노테이션 생성
  - 클라이언트가 보낸 accessToken, refreshToken을 검증한다.
  - Login 어노테이션을 이용해 subject(long) 값을 받는다.
- [x] TokenExtractor를 이용해 각 토큰을 추출

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
