### PR TITLE
[#40] 크루 상세 조회 기능 구현

### DIFF
--- a/src/main/http/crew/crew.http
+++ b/src/main/http/crew/crew.http
@@ -12,4 +12,4 @@ Content-Type: application/json
 }
 
 ### 크루 조회
-GET http://localhost:8080/crews/3
+GET http://localhost:8080/crews/12

--- a/src/main/http/crew/crew.http
+++ b/src/main/http/crew/crew.http
@@ -10,3 +10,6 @@ Content-Type: application/json
   "addressDepth1": "서울시",
   "addressDepth2": "강남구"
 }
+
+### 크루 조회
+GET http://localhost:8080/crews/3

--- a/src/main/java/kr/pickple/back/crew/controller/CrewController.java
+++ b/src/main/java/kr/pickple/back/crew/controller/CrewController.java
@@ -3,6 +3,7 @@ package kr.pickple.back.crew.controller;
 import jakarta.validation.Valid;
 import kr.pickple.back.crew.dto.request.CrewCreateRequest;
 import kr.pickple.back.crew.dto.response.CrewIdResponse;
+import kr.pickple.back.crew.dto.response.CrewProfileResponse;
 import kr.pickple.back.crew.service.CrewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,5 +26,11 @@ public class CrewController {
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(crewService.createCrew(crewCreateRequest));
+    }
+
+    @GetMapping("/{crewId}")
+    @ResponseStatus(HttpStatus.OK)
+    public CrewProfileResponse findCrewById(@PathVariable Long crewId) {
+        return crewService.findCrewById(crewId);
     }
 }

--- a/src/main/java/kr/pickple/back/crew/controller/CrewController.java
+++ b/src/main/java/kr/pickple/back/crew/controller/CrewController.java
@@ -6,12 +6,15 @@ import kr.pickple.back.crew.dto.response.CrewIdResponse;
 import kr.pickple.back.crew.dto.response.CrewProfileResponse;
 import kr.pickple.back.crew.service.CrewService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,13 +27,15 @@ public class CrewController {
     public ResponseEntity<CrewIdResponse> createCrew(
             @Valid @RequestBody final CrewCreateRequest crewCreateRequest
     ) {
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity.status(CREATED)
                 .body(crewService.createCrew(crewCreateRequest));
     }
 
     @GetMapping("/{crewId}")
-    @ResponseStatus(HttpStatus.OK)
-    public CrewProfileResponse findCrewById(@PathVariable Long crewId) {
-        return crewService.findCrewById(crewId);
+    public ResponseEntity<CrewProfileResponse> findCrewById(
+            @PathVariable final Long crewId
+    ) {
+        return ResponseEntity.status(OK)
+                .body(crewService.findCrewById(crewId));
     }
 }

--- a/src/main/java/kr/pickple/back/crew/dto/response/CrewProfileResponse.java
+++ b/src/main/java/kr/pickple/back/crew/dto/response/CrewProfileResponse.java
@@ -1,9 +1,5 @@
 package kr.pickple.back.crew.dto.response;
 
-import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.domain.CrewStatus;
 import kr.pickple.back.member.domain.Member;
@@ -12,37 +8,27 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CrewProfileResponse {
 
     private Long id;
-
     private String name;
-
     private String content;
-
     private Integer memberCount;
-
     private Integer maxMemberCount;
-
     private String profileImageUrl;
-
     private String backgroundImageUrl;
-
     private CrewStatus status;
-
     private Integer likeCount;
-
     private Integer competitionPoint;
-
     private Member leader;
-
     private String addressDepth1;
-
     private String addressDepth2;
-
     private List<Member> members;
 
     public static CrewProfileResponse fromEntity(final Crew crew) {
@@ -58,6 +44,7 @@ public class CrewProfileResponse {
                 .likeCount(crew.getLikeCount())
                 .competitionPoint(crew.getCompetitionPoint())
                 .leader(Member.builder().build())
+                .members(Arrays.asList(Member.builder().build()))
                 .addressDepth1(crew.getAddressDepth1().getName())
                 .addressDepth2(crew.getAddressDepth2().getName())
                 //TODO:추후 Member 도메인 완성되면 추가(11월 1일, 소재훈)

--- a/src/main/java/kr/pickple/back/crew/dto/response/CrewProfileResponse.java
+++ b/src/main/java/kr/pickple/back/crew/dto/response/CrewProfileResponse.java
@@ -1,0 +1,66 @@
+package kr.pickple.back.crew.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import kr.pickple.back.crew.domain.Crew;
+import kr.pickple.back.crew.domain.CrewStatus;
+import kr.pickple.back.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CrewProfileResponse {
+
+    private Long id;
+
+    private String name;
+
+    private String content;
+
+    private Integer memberCount;
+
+    private Integer maxMemberCount;
+
+    private String profileImageUrl;
+
+    private String backgroundImageUrl;
+
+    private CrewStatus status;
+
+    private Integer likeCount;
+
+    private Integer competitionPoint;
+
+    private Member leader;
+
+    private String addressDepth1;
+
+    private String addressDepth2;
+
+    private List<Member> members;
+
+    public static CrewProfileResponse fromEntity(final Crew crew) {
+        return CrewProfileResponse.builder()
+                .id(crew.getId())
+                .name(crew.getName())
+                .content(crew.getContent())
+                .memberCount(crew.getMemberCount())
+                .maxMemberCount(crew.getMaxMemberCount())
+                .profileImageUrl(crew.getProfileImageUrl())
+                .backgroundImageUrl(crew.getBackgroundImageUrl())
+                .status(crew.getStatus())
+                .likeCount(crew.getLikeCount())
+                .competitionPoint(crew.getCompetitionPoint())
+                .leader(Member.builder().build())
+                .addressDepth1(crew.getAddressDepth1().getName())
+                .addressDepth2(crew.getAddressDepth2().getName())
+                //TODO:추후 Member 도메인 완성되면 추가(11월 1일, 소재훈)
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/crew/repository/CrewRepository.java
+++ b/src/main/java/kr/pickple/back/crew/repository/CrewRepository.java
@@ -3,11 +3,7 @@ package kr.pickple.back.crew.repository;
 import kr.pickple.back.crew.domain.Crew;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface CrewRepository extends JpaRepository<Crew, Long> {
 
     boolean existsByName(String name);
-
-    Optional<Crew> findCrewById(Long id);
 }

--- a/src/main/java/kr/pickple/back/crew/repository/CrewRepository.java
+++ b/src/main/java/kr/pickple/back/crew/repository/CrewRepository.java
@@ -3,7 +3,11 @@ package kr.pickple.back.crew.repository;
 import kr.pickple.back.crew.domain.Crew;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CrewRepository extends JpaRepository<Crew, Long> {
 
     boolean existsByName(String name);
+
+    Optional<Crew> findCrewById(Long id);
 }

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -17,8 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static kr.pickple.back.crew.exception.CrewExceptionCode.CREW_IS_EXISTED;
 import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
@@ -50,12 +48,10 @@ public class CrewService {
         return CrewIdResponse.from(crewId);
     }
 
-    @Transactional
-    public CrewProfileResponse findCrewById(Long crewId) {
-        Crew crew = crewRepository.findById(crewId)
+    public CrewProfileResponse findCrewById(final Long crewId) {
+        final Crew crew = crewRepository.findById(crewId)
                 .orElseThrow(() -> new CrewException(CrewExceptionCode.CREW_NOT_FOUND));
-
-        List<Member> members = null;//TODO:추후 Member 도메인 완성되면 추가(11월 1일, 소재훈)
+        //TODO:추후 Member 도메인 완성되면 추가(11월 1일, 소재훈)
 
         return CrewProfileResponse.fromEntity(crew);
     }

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -6,7 +6,9 @@ import kr.pickple.back.common.config.property.S3Properties;
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.dto.request.CrewCreateRequest;
 import kr.pickple.back.crew.dto.response.CrewIdResponse;
+import kr.pickple.back.crew.dto.response.CrewProfileResponse;
 import kr.pickple.back.crew.exception.CrewException;
+import kr.pickple.back.crew.exception.CrewExceptionCode;
 import kr.pickple.back.crew.repository.CrewRepository;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.exception.MemberException;
@@ -14,6 +16,8 @@ import kr.pickple.back.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static kr.pickple.back.crew.exception.CrewExceptionCode.CREW_IS_EXISTED;
 import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
@@ -44,6 +48,16 @@ public class CrewService {
         final Long crewId = crewRepository.save(crew).getId();
 
         return CrewIdResponse.from(crewId);
+    }
+
+    @Transactional
+    public CrewProfileResponse findCrewById(Long crewId) {
+        Crew crew = crewRepository.findById(crewId)
+                .orElseThrow(() -> new CrewException(CrewExceptionCode.CREW_NOT_FOUND));
+
+        List<Member> members = null;//TODO:추후 Member 도메인 완성되면 추가(11월 1일, 소재훈)
+
+        return CrewProfileResponse.fromEntity(crew);
     }
 
     private void validateIsDuplicatedCrewInfo(final String name) {


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
🤜 `Controller` 단
1. 클래스 명 = **`CrewController`**
2. 메소드 명 = **`findCrewById`**
3. 반환 Http 상태 코드 = **`200`**
4. 반환 타입 = **`CrewProfile`**

<br/>

🤜 `DTO`단

Request 패키지
- 없음

<br/>

Response 패키지

1. 클래스명 = **`CrewProfile`**

⚠️  현재 Member와 관련하여 null 값으로 진행한 후, 추후에 모든 기능이 완성되면 해당 값을 조정하기로 하였기 때문에
해당 크루장(**`leader`**)의 정보 및 `members` 의 정보는 **`null`** 로 처리하였습니다.


필드 | 타입
-- | --
id | Long
name | String
content | String
memberCount | Integer
maxMemberCount | Integer
profileImageUrl | String
backgroundImageUrl | String
status | CrewStatus
likeCount | Integer
competitionPoint | Integer
leader | 해당  크루장 Member 배열
addressDepth1 | String
addressDepth2 | String
members | 해당 크루 member 배열


<!-- notionvc: df9ff563-4682-4a45-ac9a-bc267e99b57a -->

<br/>

🤜 `Repository`단
1. 클래스명 = `CrewRepository`
2. 메소드명 = `findCrewById`
3. 반환 타입 = `Optional<Crew>`

- 이전 프론트 분들과 이야기 했을 당시, **null** 값이 아닌 **Optional** 처리를 선호하는 것 같아 반환 타입으로 **Optional**을 사용하였습니다.

<br/>

🤜 `Service`단
1. **클래스명 = `CrewService`**
2. **메소드 명 = `findCrewById`**
3. **반환 타입 = `CrewProfileResponse`**

⚠️  해당 부분의 find문에서 **`@Transactional`** 어노테이션을 붙여 처리하였습니다.

**👉🏻 왜 붙였는가?**

- 보통 find문 시, **`@Transactional`** 어노테이션을 붙이지 않습니다. 그러나 해당로직 실행 시 `LazyInitializationException`가 발생됩니다. 
- 해당 문제는 Hibernate가 LAZY로 설정된 `AddressDepth1`와 `AddressDepth2`를 초기화하는 데 필요한 세션이 없을 때 발생하는 예외입니다.
- 따라서 해당 문제를 피하기위한 방법으로  `@Transactional` 어노테이션을 사용하여 `CrewService`의 `findCrewById` 메소드를 트랜잭션 범위에서 실행하도록 설정하였습니다. 이렇게 하면 `findCrewById` 메소드 실행 동안 영속성 컨텍스트가 열려있어, 필요한 시점에 LAZY로 설정된 엔티티를 초기화할 수 있으며, 정상적으로 실행 가능합니다.

<br/>

🚨 `@Transactional` 어노테이션을 안 붙일 시 발생하는 오류

![문제 발생](https://github.com/Java-and-Script/pickple-back/assets/52352476/7932fc6a-fceb-49e8-bbae-1cfca877dcee)

<br/>

🤜 **정상 실행 화면**
![문제 해결](https://github.com/Java-and-Script/pickple-back/assets/52352476/5e086576-445f-4ed5-8896-f09abebd5867)

<br/>

### 🤜  리팩토링
- **해당 코드에 남겨주신 코멘트에 대한 리팩토링을 진행**하였습니다
- **팀 컨벤션에 맞춰 작성하도록 수정**하였습니다.
- 수정 시  해당 부분에서 이전 발생했던 LazyInitializationException가 해결되어`@Transactional` 어노테이션을 제거하였습니다~

![실행 - 크루 상세 조회](https://github.com/Java-and-Script/pickple-back/assets/52352476/6352aa38-30c8-4c74-846a-58fc05f7310d)


---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  크루의 상세조회 기능 개발

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 크루 생성 작업이 머지가 되지 않은 상황이기에, Crew 도메인에서 생성 시의 도메인 로직 그대로 가져왔습니다.
- 이 부분은 두 PR이 머지 후, 조정하면 되기때문에 크게 문제되지 않습니다.
- 빠른 리뷰 부탁드립니다.

