### PR TITLE
[#54] 만료된 AccessToken 재발급 기능 구현

### DIFF
--- a/src/main/java/kr/pickple/back/auth/controller/OauthController.java
+++ b/src/main/java/kr/pickple/back/auth/controller/OauthController.java
@@ -73,10 +73,10 @@ public class OauthController {
             @CookieValue("refresh-token") final String refreshToken,
             @RequestHeader("Authorization") final String authorizationHeader
     ) {
-        final AccessTokenResponse modifiedAccessToken = oauthService.regenerateAccessToken(refreshToken,
+        final AccessTokenResponse regeneratedAccessToken = oauthService.regenerateAccessToken(refreshToken,
                 authorizationHeader);
 
         return ResponseEntity.status(CREATED)
-                .body(modifiedAccessToken);
+                .body(regeneratedAccessToken);
     }
 }

--- a/src/main/java/kr/pickple/back/auth/controller/OauthController.java
+++ b/src/main/java/kr/pickple/back/auth/controller/OauthController.java
@@ -69,11 +69,11 @@ public class OauthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<AccessTokenResponse> modificationAccessToken(
+    public ResponseEntity<AccessTokenResponse> regenerateAccessToken(
             @CookieValue("refresh-token") final String refreshToken,
             @RequestHeader("Authorization") final String authorizationHeader
     ) {
-        final AccessTokenResponse modifiedAccessToken = oauthService.modificationAccessToken(refreshToken,
+        final AccessTokenResponse modifiedAccessToken = oauthService.regenerateAccessToken(refreshToken,
                 authorizationHeader);
 
         return ResponseEntity.status(CREATED)

--- a/src/main/java/kr/pickple/back/auth/controller/OauthController.java
+++ b/src/main/java/kr/pickple/back/auth/controller/OauthController.java
@@ -7,8 +7,11 @@ import java.io.IOException;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.pickple.back.auth.config.property.JwtProperties;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
+import kr.pickple.back.auth.dto.response.AccessTokenResponse;
 import kr.pickple.back.auth.service.OauthService;
 import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
 import lombok.RequiredArgsConstructor;
@@ -62,5 +66,17 @@ public class OauthController {
 
         return ResponseEntity.status(OK)
                 .body(authenticatedMemberResponse);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AccessTokenResponse> modificationAccessToken(
+            @CookieValue("refresh-token") final String refreshToken,
+            @RequestHeader("Authorization") final String authorizationHeader
+    ) {
+        final AccessTokenResponse modifiedAccessToken = oauthService.modificationAccessToken(refreshToken,
+                authorizationHeader);
+
+        return ResponseEntity.status(CREATED)
+                .body(modifiedAccessToken);
     }
 }

--- a/src/main/java/kr/pickple/back/auth/domain/token/RefreshToken.java
+++ b/src/main/java/kr/pickple/back/auth/domain/token/RefreshToken.java
@@ -11,14 +11,14 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
 
     @Id
     private String token;
 
-    @NotNull
     @Getter
+    @NotNull
     private Long memberId;
 }

--- a/src/main/java/kr/pickple/back/auth/domain/token/RefreshToken.java
+++ b/src/main/java/kr/pickple/back/auth/domain/token/RefreshToken.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -18,5 +19,6 @@ public class RefreshToken {
     private String token;
 
     @NotNull
+    @Getter
     private Long memberId;
 }

--- a/src/main/java/kr/pickple/back/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/kr/pickple/back/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,11 @@
+package kr.pickple.back.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class AccessTokenResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/kr/pickple/back/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/pickple/back/auth/exception/AuthExceptionCode.java
@@ -18,7 +18,7 @@ public enum AuthExceptionCode implements ExceptionCode {
     AUTH_INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUT-006", "유효하지 않은 RefreshToken"),
     AUTH_INVALID_REGISTER_TOKEN(HttpStatus.BAD_REQUEST, "AUT-007", "유효하지 않은 RegisterToken"),
     AUTH_NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "AUT-008", "RefreshToken이 존재하지 않음"),
-    ;
+    AUTH_FAIL_TO_VALIDATE_TOKEN(HttpStatus.BAD_REQUEST, "AUT-009", "토큰을 검증할 수 없음");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/pickple/back/auth/service/OauthService.java
+++ b/src/main/java/kr/pickple/back/auth/service/OauthService.java
@@ -69,17 +69,17 @@ public class OauthService {
         return AuthenticatedMemberResponse.of(oauthMember, registerToken);
     }
 
-    public AccessTokenResponse modificationAccessToken(final String refreshToken, final String authorizationHeader) {
+    public AccessTokenResponse regenerateAccessToken(final String refreshToken, final String authorizationHeader) {
         final String accessToken = tokenExtractor.extractAccessToken(authorizationHeader);
 
         if (jwtProvider.isValidRefreshAndInvalidAccess(refreshToken, accessToken)) {
             final RefreshToken validRefreshToken = refreshTokenRepository.findById(refreshToken)
                     .orElseThrow(() -> new AuthException(AUTH_INVALID_REFRESH_TOKEN));
 
-            final String modifiedAccessToken = jwtProvider.regenerateAccessToken(
+            final String regeneratedAccessToken = jwtProvider.regenerateAccessToken(
                     validRefreshToken.getMemberId().toString());
 
-            return AccessTokenResponse.of(modifiedAccessToken);
+            return AccessTokenResponse.of(regeneratedAccessToken);
         }
 
         if (jwtProvider.isValidRefreshAndValidAccess(refreshToken, accessToken)) {


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 만료된 AccessToken을 재발급 받는 기능을 구현한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] 만료된 AccessToken을 받아 새로운 AccessToken을 발급하는 컨트롤러, 서비스 작성

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 사용자의 AccessToken 기한이 만료되면 refresh API를 이용하여 새로운 AccessToken을 발급한다.

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
