### PR TITLE
[#69] 다른 사용자(호스트, 게스트) 매너 스코어 리뷰 기능 추가

### DIFF
--- a/src/main/http/game/game.http
+++ b/src/main/http/game/game.http
@@ -27,7 +27,7 @@ Content-Type: application/json
 }
 
 ### 게스트 모집 참여 신청 수락
-PATCH http://localhost:8080/games/2/members/3
+PATCH http://localhost:8080/games/2/members/2
 Content-Type: application/json
 
 {
@@ -42,3 +42,20 @@ GET http://localhost:8080/games/2/members?status=대기
 
 ### 게스트 모집에 확정된 사용자 정보 목록 조회
 GET http://localhost:8080/games/2/members?status=확정
+
+### 다른 사용자(호스트, 게스트) 매너 스코어 리뷰
+PATCH http://localhost:8080/games/1/members/manner-scores
+Content-Type: application/json
+
+{
+  "mannerScoreReviews": [
+    {
+      "memberId": 1,
+      "mannerScore": 1
+    },
+    {
+      "memberId": 2,
+      "mannerScore": -1
+    }
+  ]
+}

--- a/src/main/java/kr/pickple/back/game/controller/GameController.java
+++ b/src/main/java/kr/pickple/back/game/controller/GameController.java
@@ -2,6 +2,8 @@ package kr.pickple.back.game.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +20,8 @@ import kr.pickple.back.common.domain.RegistrationStatus;
 import kr.pickple.back.game.dto.request.GameCreateRequest;
 import kr.pickple.back.game.dto.request.GameMemberCreateRequest;
 import kr.pickple.back.game.dto.request.GameMemberRegistrationStatusUpdateRequest;
+import kr.pickple.back.game.dto.request.MannerScoreReview;
+import kr.pickple.back.game.dto.request.MannerScoreReviewsRequest;
 import kr.pickple.back.game.dto.response.GameIdResponse;
 import kr.pickple.back.game.dto.response.GameResponse;
 import kr.pickple.back.game.service.GameService;
@@ -71,6 +75,18 @@ public class GameController {
     @DeleteMapping("/{gameId}/members/{memberId}")
     public ResponseEntity<Void> deleteGameMember(@PathVariable final Long gameId, @PathVariable final Long memberId) {
         gameService.deleteGameMember(gameId, memberId);
+
+        return ResponseEntity.status(NO_CONTENT)
+                .build();
+    }
+
+    @PatchMapping("/{gameId}/members/manner-scores")
+    public ResponseEntity<Void> reviewMannerScores(
+            @PathVariable final Long gameId,
+            @Valid @RequestBody final MannerScoreReviewsRequest mannerScoreReviewsRequest
+    ) {
+        final List<MannerScoreReview> mannerScoreReviews = mannerScoreReviewsRequest.getMannerScoreReviews();
+        gameService.reviewMannerScores(gameId, mannerScoreReviews);
 
         return ResponseEntity.status(NO_CONTENT)
                 .build();

--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -143,8 +143,8 @@ public class Game extends BaseEntity {
         return gamePositions.getPositions();
     }
 
-    public List<Member> getMembers(final RegistrationStatus status) {
-        return gameMembers.getMembers(status);
+    public List<Member> getMembersByStatus(final RegistrationStatus status) {
+        return gameMembers.getMembersByStatus(status);
     }
 
     public void addGameMember(final Member member) {

--- a/src/main/java/kr/pickple/back/game/domain/GameMembers.java
+++ b/src/main/java/kr/pickple/back/game/domain/GameMembers.java
@@ -18,7 +18,7 @@ public class GameMembers {
     @OneToMany(mappedBy = "game", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<GameMember> gameMembers = new ArrayList<>();
 
-    public List<Member> getMembers(final RegistrationStatus status) {
+    public List<Member> getMembersByStatus(final RegistrationStatus status) {
         return gameMembers.stream()
                 .filter(gameMember -> gameMember.equalsStatus(status))
                 .map(GameMember::getMember)

--- a/src/main/java/kr/pickple/back/game/dto/request/MannerScoreReview.java
+++ b/src/main/java/kr/pickple/back/game/dto/request/MannerScoreReview.java
@@ -1,0 +1,23 @@
+package kr.pickple.back.game.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MannerScoreReview {
+
+    @NotNull(message = "회원 ID가 입력되지 않음")
+    @Positive(message = "회원 ID는 1이상의 자연수로 입력")
+    private Long memberId;
+
+    @NotNull(message = "리뷰에 사용되는 매너 스코어가 입력되지 않음")
+    @Min(value = -1, message = "리뷰에 사용되는 매너 스코어는 -1보다 작을 수 없음")
+    @Max(value = 1, message = "리뷰에 사용되는 매너 스코어는 1보다 클 수 없음")
+    private Integer mannerScore;
+}

--- a/src/main/java/kr/pickple/back/game/dto/request/MannerScoreReviewsRequest.java
+++ b/src/main/java/kr/pickple/back/game/dto/request/MannerScoreReviewsRequest.java
@@ -1,0 +1,18 @@
+package kr.pickple.back.game.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MannerScoreReviewsRequest {
+
+    @Valid
+    @NotNull(message = "매너 스코어 리뷰 목록이 입력되지 않음")
+    private List<MannerScoreReview> mannerScoreReviews;
+}

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -67,7 +67,7 @@ public class GameService {
 
     public GameResponse findAllGameMembers(final Long gameId, final RegistrationStatus status) {
         final Game game = findGameById(gameId);
-        final List<MemberResponse> memberResponses = game.getMembers(status)
+        final List<MemberResponse> memberResponses = game.getMembersByStatus(status)
                 .stream()
                 .map(MemberResponse::from)
                 .toList();
@@ -115,7 +115,7 @@ public class GameService {
     }
 
     private Member getReviewedMember(final Game game, final Long reviewedMemberId) {
-        return game.getMembers(CONFIRMED)
+        return game.getMembersByStatus(CONFIRMED)
                 .stream()
                 .filter(confirmedMember -> confirmedMember.getId() == reviewedMemberId)
                 .findFirst()

--- a/src/main/java/kr/pickple/back/member/domain/Member.java
+++ b/src/main/java/kr/pickple/back/member/domain/Member.java
@@ -1,5 +1,7 @@
 package kr.pickple.back.member.domain;
 
+import static kr.pickple.back.member.exception.MemberExceptionCode.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +23,7 @@ import kr.pickple.back.address.domain.AddressDepth1;
 import kr.pickple.back.address.domain.AddressDepth2;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
 import kr.pickple.back.common.domain.BaseEntity;
+import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.util.MemberStatusConverter;
 import kr.pickple.back.position.domain.Position;
 import lombok.AccessLevel;
@@ -34,6 +37,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "id")
 public class Member extends BaseEntity {
+
+    private static final List<Integer> MANNER_SCORE_POINT_RANGE = List.of(-1, 0, 1);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -113,7 +118,13 @@ public class Member extends BaseEntity {
                 .toList();
     }
 
-    public void updateMannerScore(final Integer mannerScorePoints) {
-        this.mannerScore += mannerScorePoints;
+    public void updateMannerScore(final Integer mannerScorePoint) {
+        if (MANNER_SCORE_POINT_RANGE.contains(mannerScorePoint)) {
+            this.mannerScore += mannerScorePoint;
+
+            return;
+        }
+
+        throw new MemberException(MEMBER_UPDATING_MANNER_SCORE_POINT_OUT_OF_RANGE, mannerScorePoint);
     }
 }

--- a/src/main/java/kr/pickple/back/member/domain/Member.java
+++ b/src/main/java/kr/pickple/back/member/domain/Member.java
@@ -112,4 +112,8 @@ public class Member extends BaseEntity {
                 .map(MemberPosition::getPosition)
                 .toList();
     }
+
+    public void updateMannerScore(final Integer mannerScorePoints) {
+        this.mannerScore += mannerScorePoints;
+    }
 }

--- a/src/main/java/kr/pickple/back/member/exception/MemberExceptionCode.java
+++ b/src/main/java/kr/pickple/back/member/exception/MemberExceptionCode.java
@@ -15,6 +15,7 @@ public enum MemberExceptionCode implements ExceptionCode {
     MEMBER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM-003", "사용자 상태는 활동이거나 탈퇴만 가능"),
     MEMBER_SIGNUP_OAUTH_SUBJECT_INVALID(HttpStatus.BAD_REQUEST, "MEM-004",
             "회원 가입 시, 사용자의 OAuth ID와 Provider의 정보가 유효하지 않음"),
+    MEMBER_UPDATING_MANNER_SCORE_POINT_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "MEM-005", "매너 스코어 변경 포인트가 범위를 벗어남"),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 경기에 참여한 사용자들이 다른 사용자들의 매너 스코어를 리뷰하는 기능을 완성한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 매너 스코어 리뷰 응답 DTO 작성
- [x] 매너 스코어 리뷰 기능 작성

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
