### PR TITLE
[#89] Oauth Test Fixture 적용 및 Document(RestDocs, Swagger) Test 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ asciidoctor {
 }
 
 openapi3 {
-	server = "https://api.pickple.kr"
+	server = "https://dev.pickple.kr"
 	title = "PICKPLE API 문서"
 	description = "PICKPLE 서비스의 API 문서입니다."
 	version = "0.0.1"

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -9,3 +9,6 @@ operation::oauth-login-authenticated[snippets='http-request,http-response']
 === OAUTH LOGIN REGISTRATION
 operation::oauth-login-registration[snippets='http-request,http-response']
 
+=== OAUTH ACCESS TOKEN REFRESH
+operation::oauth-access-token-refresh[snippets='http-request,http-response']
+

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,11 @@
+== Auth
+
+=== REDIRECT OAUTH PAGE
+operation::redirect-oauth-login-page[snippets='http-request,http-response']
+
+=== OAUTH LOGIN AUTHENTICATED
+operation::oauth-login-authenticated[snippets='http-request,http-response']
+
+=== OAUTH LOGIN REGISTRATION
+operation::oauth-login-registration[snippets='http-request,http-response']
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,4 +5,5 @@
 :toclevels: 2
 :sectlinks:
 
+include::auth.adoc[]
 include::member.adoc[]

--- a/src/test/java/kr/pickple/back/auth/docs/AuthDocumentTest.java
+++ b/src/test/java/kr/pickple/back/auth/docs/AuthDocumentTest.java
@@ -1,0 +1,200 @@
+package kr.pickple.back.auth.docs;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static com.epages.restdocs.apispec.Schema.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+
+import kr.pickple.back.auth.domain.oauth.OauthProvider;
+import kr.pickple.back.auth.service.OauthService;
+import kr.pickple.back.fixture.dto.MemberDtoFixtures;
+import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+public class AuthDocumentTest {
+
+    @MockBean
+    private OauthService oauthService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("oauth 제공자를 받으면 로그인 페이지로 리다이렉트 시킬 수 있다.")
+    void redirectOauthLoginPage() throws Exception {
+        // given
+        final String REDIRECT_URL = "https://test.url";
+
+        given(oauthService.getAuthCodeRequestUrl(any(OauthProvider.class))).willReturn(REDIRECT_URL);
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(get("/auth/{oauthProvider}", "kakao"))
+                .andExpect(status().is3xxRedirection());
+
+        // then
+        resultActions.andDo(document("redirect-oauth-login-page",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Auth")
+                                        .summary("oauth 페이지로 리다이렉트")
+                                        .description("클라이언트에서 로그인 버튼을 클릭하면 oauth 페이지로 리다이렉트 한다.")
+                                        .pathParameters(
+                                                parameterWithName("oauthProvider")
+                                                        .defaultValue("kakao")
+                                                        .type(SimpleType.STRING)
+                                                        .description("oauth 제공자")
+                                        )
+                                        .responseHeaders(
+                                                headerWithName("Location").defaultValue(REDIRECT_URL).description("리다이렉트 주소"))
+                                        .build()
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("oauth를 이용하여 로그인 할 수 있다.")
+    void oauthLogin_ReturnAuthenticated() throws Exception {
+        // given
+        final AuthenticatedMemberResponse authenticatedMemberResponse = MemberDtoFixtures.authenticatedMemberResponseLoginBuild();
+
+        given(oauthService.processLoginOrRegistration(any(OauthProvider.class), anyString())).willReturn(
+                authenticatedMemberResponse);
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                        get("/auth/login/{oauthProvider}", "kakao").param("authCode", "testCode"))
+                .andExpect(status().isOk());
+
+        // then
+        resultActions.andDo(document("oauth-login-authenticated",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Auth")
+                                        .summary("oauth 로그인")
+                                        .description("oauth를 이용하여 로그인 할 수 있다.")
+                                        .responseSchema(schema("Authenticated"))
+                                        .pathParameters(
+                                                parameterWithName("oauthProvider")
+                                                        .defaultValue("kakao")
+                                                        .type(SimpleType.STRING)
+                                                        .description("oauth 제공자")
+                                        )
+                                        .queryParameters(
+                                                parameterWithName("authCode")
+                                                        .defaultValue("testCode")
+                                                        .type(SimpleType.STRING)
+                                                        .description("oauth 로그인 후 받은 authCode")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("accessToken").type(JsonFieldType.STRING)
+                                                        .description("AccessToken"),
+                                                fieldWithPath("refreshToken").type(JsonFieldType.STRING)
+                                                        .description("RefreshToken"),
+                                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("회원 ID"),
+                                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                                fieldWithPath("profileImageUrl").type(JsonFieldType.STRING)
+                                                        .description("프로필 이미지 경로"),
+                                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                                fieldWithPath("oauthId").type(JsonFieldType.NUMBER).description("oauthId"),
+                                                fieldWithPath("oauthProvider").type(JsonFieldType.STRING)
+                                                        .description("oauth 제공자"),
+                                                fieldWithPath("addressDepth1").type(JsonFieldType.STRING)
+                                                        .description("주소1(도,시)"),
+                                                fieldWithPath("addressDepth2").type(JsonFieldType.STRING)
+                                                        .description("주소2(도,시)")
+                                        )
+                                        .responseHeaders(
+                                                headerWithName("Set-Cookie").description("refreshToken")
+                                        )
+                                        .build()
+                        )
+                )
+        ).andDo(print());
+    }
+
+    @Test
+    @DisplayName("oauth를 이용하여 로그인시 회원 정보가 존재하지 않을 경우 회원가입 관련 정보를 응답한다.")
+    void oauthLogin_ReturnRegistration() throws Exception {
+        // given
+        final AuthenticatedMemberResponse authenticatedMemberResponse = MemberDtoFixtures.authenticatedMemberResponseRegistrationBuild();
+
+        given(oauthService.processLoginOrRegistration(any(OauthProvider.class), anyString())).willReturn(
+                authenticatedMemberResponse);
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                        get("/auth/login/{oauthProvider}", "kakao").param("authCode", "testCode"))
+                .andExpect(status().isOk());
+
+        // then
+        resultActions.andDo(document("oauth-login-registration",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Auth")
+                                        .summary("oauth 회원가입")
+                                        .description("oauth를 이용하여 로그인시 회원 정보가 존재하지 않을 경우 회원가입 관련 정보를 응답한다.")
+                                        .responseSchema(schema("Registration"))
+                                        .pathParameters(
+                                                parameterWithName("oauthProvider")
+                                                        .defaultValue("kakao")
+                                                        .type(SimpleType.STRING)
+                                                        .description("oauth 제공자")
+                                        )
+                                        .queryParameters(
+                                                parameterWithName("authCode")
+                                                        .defaultValue("testCode")
+                                                        .type(SimpleType.STRING)
+                                                        .description("oauth 로그인 후 받은 authCode")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("accessToken").type(JsonFieldType.STRING)
+                                                        .description("AccessToken"),
+                                                fieldWithPath("refreshToken").type(JsonFieldType.NULL)
+                                                        .description("RefreshToken"),
+                                                fieldWithPath("id").type(JsonFieldType.NULL).description("회원 ID"),
+                                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                                fieldWithPath("profileImageUrl").type(JsonFieldType.STRING)
+                                                        .description("프로필 이미지 경로"),
+                                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                                fieldWithPath("oauthId").type(JsonFieldType.NUMBER).description("oauthId"),
+                                                fieldWithPath("oauthProvider").type(JsonFieldType.STRING)
+                                                        .description("oauth 제공자"),
+                                                fieldWithPath("addressDepth1").type(JsonFieldType.NULL)
+                                                        .description("주소1(도,시)"),
+                                                fieldWithPath("addressDepth2").type(JsonFieldType.NULL)
+                                                        .description("주소2(도,시)")
+                                        )
+                                        .build()
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/kr/pickple/back/fixture/dto/AuthDtoFixtures.java
+++ b/src/test/java/kr/pickple/back/fixture/dto/AuthDtoFixtures.java
@@ -1,0 +1,10 @@
+package kr.pickple.back.fixture.dto;
+
+import kr.pickple.back.auth.dto.response.AccessTokenResponse;
+
+public class AuthDtoFixtures {
+
+    public static AccessTokenResponse accessTokenResponseBuild() {
+        return AccessTokenResponse.of("accessToken");
+    }
+}

--- a/src/test/java/kr/pickple/back/fixture/dto/MemberDtoFixtures.java
+++ b/src/test/java/kr/pickple/back/fixture/dto/MemberDtoFixtures.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
 import kr.pickple.back.member.dto.request.MemberCreateRequest;
+import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
 
 public class MemberDtoFixtures {
 
@@ -17,6 +18,32 @@ public class MemberDtoFixtures {
                 .oauthProvider(OauthProvider.KAKAO)
                 .addressDepth1("서울시")
                 .addressDepth2("영등포구")
+                .build();
+    }
+
+    public static AuthenticatedMemberResponse authenticatedMemberResponseLoginBuild() {
+        return AuthenticatedMemberResponse.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .id(1L)
+                .nickname("강백둥")
+                .profileImageUrl("https://amazon.image/1")
+                .email("pickple1@pickple.kr")
+                .oauthId(1L)
+                .oauthProvider(OauthProvider.KAKAO)
+                .addressDepth1("서울시")
+                .addressDepth2("영등포구")
+                .build();
+    }
+
+    public static AuthenticatedMemberResponse authenticatedMemberResponseRegistrationBuild() {
+        return AuthenticatedMemberResponse.builder()
+                .accessToken("accessToken")
+                .nickname("강백둥")
+                .profileImageUrl("https://amazon.image/1")
+                .email("pickple1@pickple.kr")
+                .oauthId(1L)
+                .oauthProvider(OauthProvider.KAKAO)
                 .build();
     }
 }

--- a/src/test/java/kr/pickple/back/member/docs/MemberDocumentTest.java
+++ b/src/test/java/kr/pickple/back/member/docs/MemberDocumentTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.pickple.back.auth.domain.token.AuthTokens;
@@ -78,6 +79,7 @@ class MemberDocumentTest {
                                         .responseSchema(schema("MemberProfileResponse"))
                                         .requestHeaders(
                                                 headerWithName("Authorization")
+                                                        .type(SimpleType.STRING)
                                                         .description("Register Token"))
                                         .requestFields(
                                                 fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),

--- a/src/test/java/kr/pickple/back/member/docs/MemberDocumentTest.java
+++ b/src/test/java/kr/pickple/back/member/docs/MemberDocumentTest.java
@@ -109,7 +109,11 @@ class MemberDocumentTest {
                                                         .description("주소1(도,시)"),
                                                 fieldWithPath("addressDepth2").type(JsonFieldType.STRING)
                                                         .description("주소2(도,시)")
-                                        ).build()
+                                        )
+                                        .responseHeaders(
+                                                headerWithName("Set-Cookie").description("refreshToken")
+                                        )
+                                        .build()
                         )
                 )
         );
@@ -155,7 +159,8 @@ class MemberDocumentTest {
                                                 fieldWithPath("positions").type(JsonFieldType.ARRAY).description("주 포지션 목록"),
                                                 fieldWithPath("crews").type(JsonFieldType.NULL).description("사용자가 소속된 크루 목록")
                                                 //TODO: 추후 Crew 도메인 완성 시, 해당 필드에 대한 로직 추가 예정 (11.4 황창현)
-                                        ).build()
+                                        )
+                                        .build()
                         )
                 )
         );


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- Oauth에 관련된 Test Fixture를 적용한다.
- 적용한 Fixture를 이용하여 Document Test를 진행한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] Oauth 도메인에 Test Fixture 적용
- [X] Document Test 코드 작성

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 인증, 인가 관련 연동 이후 Controller 테스트와 Service 테스트 작성 예정입니다.

---

#### API endpoint
- /auth/{oauthProvider}
- /auth/login/{oauthProvider}?authCode={authCode}
- /auth/refresh

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
