### PR TITLE
[#100] 인증, 인가 로직 AccessToken만 검증하는 것으로 변경 처리

### DIFF
--- a/src/main/java/kr/pickple/back/auth/config/resolver/LoginTokenArgumentResolver.java
+++ b/src/main/java/kr/pickple/back/auth/config/resolver/LoginTokenArgumentResolver.java
@@ -9,9 +9,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import kr.pickple.back.auth.domain.token.AuthTokens;
 import kr.pickple.back.auth.domain.token.JwtProvider;
 import lombok.RequiredArgsConstructor;
 
@@ -35,18 +32,8 @@ public class LoginTokenArgumentResolver implements HandlerMethodArgumentResolver
             final NativeWebRequest webRequest,
             final WebDataBinderFactory binderFactory
     ) {
-        final Cookie[] cookies = webRequest.getNativeRequest(HttpServletRequest.class)
-                .getCookies();
-
         final String accessToken = tokenExtractor.extractAccessToken(webRequest.getHeader(AUTHORIZATION));
-        final String refreshToken = tokenExtractor.extractRefreshToken(cookies);
-
-        final AuthTokens authTokens = AuthTokens.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
-
-        jwtProvider.validateTokens(authTokens);
+        jwtProvider.validateAccessToken(accessToken);
 
         return Long.parseLong(jwtProvider.getSubject(accessToken));
     }

--- a/src/main/java/kr/pickple/back/auth/domain/token/JwtProvider.java
+++ b/src/main/java/kr/pickple/back/auth/domain/token/JwtProvider.java
@@ -81,7 +81,7 @@ public class JwtProvider {
         validateRefreshToken(authTokens.getRefreshToken());
     }
 
-    private void validateAccessToken(final String accessToken) {
+    public void validateAccessToken(final String accessToken) {
         try {
             parseToken(accessToken);
         } catch (final ExpiredJwtException e) {


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 로그인 후 인증, 인가가 필요한 API 요청시 AccessToken만 검증하도록 로직 변경

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] LoginArgumentResolver수정

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---

### 기타
<!-- 작성하지 않으면 삭제 -->

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
