### PR TITLE
[#102] 사용자 프로필 조회 시 대기 상태의 크루 목록 보이는 버그 해결

### DIFF
--- a/src/main/java/kr/pickple/back/member/domain/Member.java
+++ b/src/main/java/kr/pickple/back/member/domain/Member.java
@@ -133,10 +133,6 @@ public class Member extends BaseEntity {
         return memberCrews.getCreatedCrewsByMember(this);
     }
 
-    public List<Crew> getAllCrews() {
-        return memberCrews.getAllCrews();
-    }
-
     public List<Game> getGamesByStatus(final RegistrationStatus status) {
         return memberGames.getGamesByStatus(status);
     }

--- a/src/main/java/kr/pickple/back/member/domain/MemberCrews.java
+++ b/src/main/java/kr/pickple/back/member/domain/MemberCrews.java
@@ -29,10 +29,4 @@ public class MemberCrews {
                 .filter(crew -> crew.isLeader(member))
                 .toList();
     }
-
-    public List<Crew> getAllCrews() {
-        return memberCrews.stream()
-                .map(CrewMember::getCrew)
-                .toList();
-    }
 }

--- a/src/main/java/kr/pickple/back/member/service/MemberService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberService.java
@@ -75,7 +75,7 @@ public class MemberService {
 
     public MemberProfileResponse findMemberProfileById(final Long memberId) {
         final Member member = findMemberById(memberId);
-        final List<CrewResponse> crewResponses = member.getAllCrews()
+        final List<CrewResponse> crewResponses = member.getCrewsByStatus(CONFIRMED)
                 .stream()
                 .map(CrewResponse::from)
                 .toList();


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 사용자 프로필을 조회할 때는 크루원인 크루들만 나와야 하는데, 대기 상태의 크루들도 보이는 문제 발생
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] Crew 조회 시 status를 넣어서 조회하여 문제 해결하기

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
