### PR TITLE
[#127] 게스트 모집 API 인가 처리 추가

### DIFF
--- a/src/main/java/kr/pickple/back/common/util/DateTimeUtil.java
+++ b/src/main/java/kr/pickple/back/common/util/DateTimeUtil.java
@@ -10,10 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DateTimeUtil {
 
-    public static boolean isAfterThan(final LocalDate date, final LocalTime time) {
+    public static boolean isAfterThanNow(final LocalDate date, final LocalTime time) {
         final LocalDateTime datetime = LocalDateTime.of(date, time);
         final LocalDateTime now = LocalDateTime.now();
 
-        return now.isAfter(datetime);
+        return datetime.isAfter(now);
     }
 }

--- a/src/main/java/kr/pickple/back/common/util/DateTimeUtil.java
+++ b/src/main/java/kr/pickple/back/common/util/DateTimeUtil.java
@@ -1,0 +1,19 @@
+package kr.pickple.back.common.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DateTimeUtil {
+
+    public static boolean isAfterThan(final LocalDate date, final LocalTime time) {
+        final LocalDateTime datetime = LocalDateTime.of(date, time);
+        final LocalDateTime now = LocalDateTime.now();
+
+        return now.isAfter(datetime);
+    }
+}

--- a/src/main/java/kr/pickple/back/game/controller/GameController.java
+++ b/src/main/java/kr/pickple/back/game/controller/GameController.java
@@ -81,7 +81,7 @@ public class GameController {
             @RequestParam final RegistrationStatus status
     ) {
         return ResponseEntity.status(OK)
-                .body(gameService.findAllGameMembers(gameId, status));
+                .body(gameService.findAllGameMembers(loggedInMemberId, gameId, status));
     }
 
     @PatchMapping("/{gameId}/members/{memberId}")
@@ -91,7 +91,12 @@ public class GameController {
             @PathVariable final Long memberId,
             @Valid @RequestBody final GameMemberRegistrationStatusUpdateRequest gameMemberRegistrationStatusUpdateRequest
     ) {
-        gameService.updateGameMemberRegistrationStatus(gameId, memberId, gameMemberRegistrationStatusUpdateRequest);
+        gameService.updateGameMemberRegistrationStatus(
+                loggedInMemberId,
+                gameId,
+                memberId,
+                gameMemberRegistrationStatusUpdateRequest
+        );
 
         return ResponseEntity.status(NO_CONTENT)
                 .build();
@@ -103,7 +108,7 @@ public class GameController {
             @PathVariable final Long gameId,
             @PathVariable final Long memberId
     ) {
-        gameService.deleteGameMember(gameId, memberId);
+        gameService.deleteGameMember(loggedInMemberId, gameId, memberId);
 
         return ResponseEntity.status(NO_CONTENT)
                 .build();
@@ -116,7 +121,7 @@ public class GameController {
             @Valid @RequestBody final MannerScoreReviewsRequest mannerScoreReviewsRequest
     ) {
         final List<MannerScoreReview> mannerScoreReviews = mannerScoreReviewsRequest.getMannerScoreReviews();
-        gameService.reviewMannerScores(gameId, mannerScoreReviews);
+        gameService.reviewMannerScores(loggedInMemberId, gameId, mannerScoreReviews);
 
         return ResponseEntity.status(NO_CONTENT)
                 .build();

--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -155,11 +155,11 @@ public class Game extends BaseEntity {
         gameMembers.addGameMember(this, member);
     }
 
-    public Boolean isHost(final Member member) {
-        return member.equals(host);
-    }
-
     public void increaseViewCount() {
         viewCount++;
+    }
+
+    public Boolean isHost(final Member member) {
+        return member.equals(host);
     }
 }

--- a/src/main/java/kr/pickple/back/game/exception/GameExceptionCode.java
+++ b/src/main/java/kr/pickple/back/game/exception/GameExceptionCode.java
@@ -15,7 +15,13 @@ public enum GameExceptionCode implements ExceptionCode {
     GAME_MEMBER_IS_EXISTED(HttpStatus.BAD_REQUEST, "GAM-003", "이미 해당 게스트 모집글에 참여 신청한 사용자"),
     GAME_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "GAM-004", "게스트 모집글에 참여 신청된 혹은 확정된 사용자들 중에서 해당 사용자를 찾을 수 없음"),
     GAME_POSITIONS_IS_DUPLICATED(HttpStatus.BAD_REQUEST, "GAM-005", "게스트 모집글의 포지션 목록에 중복이 존재함"),
-    GAME_SEARCH_CATEGORY_IS_INVALID(HttpStatus.BAD_REQUEST, "GAM-006", "게스트 모집글의 검색 카테고리 키워드가 유효하지 않음");
+    GAME_SEARCH_CATEGORY_IS_INVALID(HttpStatus.BAD_REQUEST, "GAM-006", "게스트 모집글의 검색 카테고리 키워드가 유효하지 않음"),
+    GAME_MEMBER_IS_NOT_HOST(HttpStatus.FORBIDDEN, "GAM-007", "해당 게스트 모집글의 호스트 권한이 필요함"),
+    GAME_HOST_CANNOT_BE_DELETED(HttpStatus.BAD_REQUEST, "GAM-008", "호스트는 자신의 게스트 모집글에서 삭제될 수 없음"),
+    GAME_MEMBER_STATUS_IS_NOT_WAITING(HttpStatus.BAD_REQUEST, "GAM-009", "해당 게스트 모집글에 참여 신청 대기 상태가 아니라면, 참여 신청을 취소할 수 없음"),
+    GAME_NOT_ALLOWED_TO_DELETE_GAME_MEMBER(HttpStatus.FORBIDDEN, "GAM-010", "해당 사용자의 게스트 모집글 참여 신청을 거절 혹은 취소할 권한이 필요함"),
+    GAME_MEMBERS_CAN_REVIEW_AFTER_PLAYING(HttpStatus.BAD_REQUEST, "GAM-011", "경기 종료 이전에는 리뷰를 남길 수 없음"),
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/pickple/back/game/exception/GameExceptionCode.java
+++ b/src/main/java/kr/pickple/back/game/exception/GameExceptionCode.java
@@ -21,6 +21,7 @@ public enum GameExceptionCode implements ExceptionCode {
     GAME_MEMBER_STATUS_IS_NOT_WAITING(HttpStatus.BAD_REQUEST, "GAM-009", "해당 게스트 모집글에 참여 신청 대기 상태가 아니라면, 참여 신청을 취소할 수 없음"),
     GAME_NOT_ALLOWED_TO_DELETE_GAME_MEMBER(HttpStatus.FORBIDDEN, "GAM-010", "해당 사용자의 게스트 모집글 참여 신청을 거절 혹은 취소할 권한이 필요함"),
     GAME_MEMBERS_CAN_REVIEW_AFTER_PLAYING(HttpStatus.BAD_REQUEST, "GAM-011", "경기 종료 이전에는 리뷰를 남길 수 없음"),
+    GAME_MEMBER_CANNOT_REVIEW_SELF(HttpStatus.BAD_REQUEST, "GAM-012", "자기 자신에게 리뷰를 남길 수 없음"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -206,6 +206,7 @@ public class GameService {
     ) {
         final GameMember gameMember = findGameMemberByGameIdAndMemberId(gameId, loggedInMemberId);
         final Game game = gameMember.getGame();
+        final Member loggedInMember = gameMember.getMember();
 
         if (isGameNotOver(game)) {
             throw new GameException(GAME_MEMBERS_CAN_REVIEW_AFTER_PLAYING, game.getPlayDate(), game.getPlayEndTime());
@@ -213,8 +214,15 @@ public class GameService {
 
         mannerScoreReviews.forEach(review -> {
             final Member reviewedMember = getReviewedMember(game, review.getMemberId());
+            validateIsSelfReview(loggedInMember, reviewedMember);
             reviewedMember.updateMannerScore(review.getMannerScore());
         });
+    }
+
+    private void validateIsSelfReview(final Member loggedInMember, final Member reviewedMember) {
+        if (loggedInMember.equals(reviewedMember)) {
+            throw new GameException(GAME_MEMBER_CANNOT_REVIEW_SELF, loggedInMember.getId(), reviewedMember.getId());
+        }
     }
 
     private GameMember findGameMemberByGameIdAndMemberId(final Long gameId, final Long memberId) {

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -231,7 +231,7 @@ public class GameService {
     }
 
     private boolean isGameNotOver(final Game game) {
-        return !DateTimeUtil.isAfterThan(game.getPlayDate(), game.getPlayEndTime());
+        return DateTimeUtil.isAfterThanNow(game.getPlayDate(), game.getPlayEndTime());
     }
 
     private Member getReviewedMember(final Game game, final Long reviewedMemberId) {

--- a/src/main/java/kr/pickple/back/member/domain/Member.java
+++ b/src/main/java/kr/pickple/back/member/domain/Member.java
@@ -149,6 +149,7 @@ public class Member extends BaseEntity {
     public void updateMannerScore(final Integer mannerScorePoint) {
         if (MANNER_SCORE_POINT_RANGE.contains(mannerScorePoint)) {
             this.mannerScore += mannerScorePoint;
+            this.mannerScoreCount += 1;
 
             return;
         }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 게스트 모집 API 중 일부에 인가 처리를 추가한다.
- 매너 스코어 리뷰 반영 시, 현재 시간 기준으로 경기가 종료되지 않았다면 예외를 발생시킨다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 게스트 모집 참여 신청 기능에 인가 처리를 추가한다.
- [x] 게스트 모집 참여 신청 수락 기능에 인가 처리를 추가한다.
- [x] 게스트 모집 참여 신청 거절/취소 기능에 인가 처리를 추가한다.
- [x] 게스트 모집에 참여 신청된 혹은 확정된 사용자 정보 목록 조회 기능에 인가 처리를 추가한다.
- [x] 다른 사용자(호스트, 게스트) 매너 스코어 리뷰 기능에 인가 처리를 추가한다.
- [x] 매너 스코어 리뷰 반영 시, 현재 시간 기준으로 경기가 종료되지 않았다면 예외를 발생시키는 로직 추가

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
