### PR TITLE
[#134] container registry를 docker hub로 변경하고 관련 설정하기

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -27,19 +27,18 @@ jobs:
         with:
           arguments: build
 
-      - name: Container Registry Login
+      - name: Docker Hub Login
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-          password: ${{ secrets.ACCESS_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Docker Image Build and Push
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: ${{ secrets.CONTAINER_REGISTRY_IMAGE_TAG }}
+          tags: ${{ secrets.DOCKER_HUB_REPOSITORY }}
 
       - name: Copy Deployment Files to EC2
         uses: appleboy/scp-action@master
@@ -58,7 +57,7 @@ jobs:
           username: ${{ secrets.EC2_INSTANCE_USERNAME }}
           key: ${{ secrets.EC2_INSTANCE_PRIVATE_KEY }}
           script: |
-            docker pull ${{ secrets.CONTAINER_REGISTRY_IMAGE_TAG }}
+            docker pull ${{ secrets.DOCKER_HUB_REPOSITORY }}
             cd ~/pickple/deploy/dev
             docker-compose -p pickple-dev down
             docker-compose -p pickple-dev up -d


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- github container registry의 유료 이슈로 인한, registry 설정을 docker hub 기준으로 변경한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] docker hub private repository 생성
- [x] cd-dev.yml 에서 docker login 및 pull, push 관련 환경 변수 수정
- [x] ec2 인스턴스 내에서 docker login 다시 하기

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
