### PR TITLE
[#141] 사용자 근처 크루 목록 조회에서 인증 로직 제거

### DIFF
--- a/src/main/http/crew/crew.http
+++ b/src/main/http/crew/crew.http
@@ -40,4 +40,3 @@ Content-Type: application/json
 
 ### 사용자 근처 크루 목록 조회
 GET http://localhost:8080/crews?addressDepth1=서울시&addressDepth2=영등포구&page=0&size=10
-Authorization: Bearer {{token1}}

--- a/src/main/java/kr/pickple/back/crew/controller/CrewController.java
+++ b/src/main/java/kr/pickple/back/crew/controller/CrewController.java
@@ -1,15 +1,9 @@
 package kr.pickple.back.crew.controller;
 
-import jakarta.validation.Valid;
-import kr.pickple.back.auth.config.resolver.Login;
-import kr.pickple.back.common.domain.RegistrationStatus;
-import kr.pickple.back.crew.dto.request.CrewCreateRequest;
-import kr.pickple.back.crew.dto.request.CrewMemberUpdateStatusRequest;
-import kr.pickple.back.crew.dto.response.CrewIdResponse;
-import kr.pickple.back.crew.dto.response.CrewProfileResponse;
-import kr.pickple.back.crew.service.CrewMemberService;
-import kr.pickple.back.crew.service.CrewService;
-import lombok.RequiredArgsConstructor;
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,9 +16,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
-import static org.springframework.http.HttpStatus.*;
+import jakarta.validation.Valid;
+import kr.pickple.back.auth.config.resolver.Login;
+import kr.pickple.back.common.domain.RegistrationStatus;
+import kr.pickple.back.crew.dto.request.CrewCreateRequest;
+import kr.pickple.back.crew.dto.request.CrewMemberUpdateStatusRequest;
+import kr.pickple.back.crew.dto.response.CrewIdResponse;
+import kr.pickple.back.crew.dto.response.CrewProfileResponse;
+import kr.pickple.back.crew.service.CrewMemberService;
+import kr.pickple.back.crew.service.CrewService;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -99,12 +100,11 @@ public class CrewController {
 
     @GetMapping
     public ResponseEntity<List<CrewProfileResponse>> findCrewsByAddress(
-            @Login final Long loggedInMemberId,
             @RequestParam final String addressDepth1,
             @RequestParam final String addressDepth2,
             final Pageable pageable
     ) {
         return ResponseEntity.status(OK)
-                .body(crewService.findCrewByAddress(loggedInMemberId,addressDepth1, addressDepth2, pageable));
+                .body(crewService.findCrewByAddress(addressDepth1, addressDepth2, pageable));
     }
 }

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -1,5 +1,16 @@
 package kr.pickple.back.crew.service;
 
+import static kr.pickple.back.common.domain.RegistrationStatus.*;
+import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
+import static kr.pickple.back.member.exception.MemberExceptionCode.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.pickple.back.address.dto.response.MainAddressResponse;
 import kr.pickple.back.address.service.AddressService;
 import kr.pickple.back.common.config.property.S3Properties;
@@ -15,16 +26,6 @@ import kr.pickple.back.member.dto.response.MemberResponse;
 import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static kr.pickple.back.common.domain.RegistrationStatus.CONFIRMED;
-import static kr.pickple.back.crew.exception.CrewExceptionCode.CREW_IS_EXISTED;
-import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
 @Service
 @Transactional(readOnly = true)
@@ -74,14 +75,10 @@ public class CrewService {
     }
 
     public List<CrewProfileResponse> findCrewByAddress(
-            final Long loggedInMemberId,
             final String addressDepth1,
             final String addressDepth2,
             final Pageable pageable
     ) {
-        final Member member = memberRepository.findById(loggedInMemberId)
-                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND, loggedInMemberId));
-
         final MainAddressResponse mainAddressResponse = addressService.findMainAddressByNames(addressDepth1,
                 addressDepth2);
 


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 로그인이 되지 않은 사용자도 사용자 근처 크루 목록 조회를 할 수 있게 인증 로직을 제거한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] Controller, Service에서 관련 로직 삭제
- [X] 관련 http 요청에서 Authorization 삭제

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
