### PR TITLE
[#138] 게스트 모집 상세 주소 → 좌표 값 변환 API 구현

### DIFF
--- a/src/main/java/kr/pickple/back/address/config/KakaoAddressSearchHttpInterfaceConfig.java
+++ b/src/main/java/kr/pickple/back/address/config/KakaoAddressSearchHttpInterfaceConfig.java
@@ -1,0 +1,36 @@
+package kr.pickple.back.address.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import kr.pickple.back.address.service.kakao.KakaoAddressSearchApiClient;
+import kr.pickple.back.auth.config.WebClientConfig;
+import kr.pickple.back.auth.config.property.KakaoOauthProperties;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class KakaoAddressSearchHttpInterfaceConfig {
+
+    private final KakaoOauthProperties kakaoOauthProperties;
+
+    @Bean
+    public KakaoAddressSearchApiClient kakaoAddressSearchApiClient() {
+        return createHttpInterface(KakaoAddressSearchApiClient.class);
+    }
+
+    private <T> T createHttpInterface(final Class<T> clazz) {
+        final WebClient webClient = WebClient.builder()
+                .baseUrl(kakaoOauthProperties.getAddressUrl())
+                .exchangeStrategies(WebClientConfig.getExchangeStrategies())
+                .build();
+        final HttpServiceProxyFactory build = HttpServiceProxyFactory
+                .builder(WebClientAdapter.forClient(webClient))
+                .build();
+
+        return build.createClient(clazz);
+    }
+}

--- a/src/main/java/kr/pickple/back/address/dto/kakao/Coordinate.java
+++ b/src/main/java/kr/pickple/back/address/dto/kakao/Coordinate.java
@@ -1,0 +1,15 @@
+package kr.pickple.back.address.dto.kakao;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Coordinate {
+
+    private Double x;
+    private Double y;
+}

--- a/src/main/java/kr/pickple/back/address/dto/kakao/KakaoAddressResponse.java
+++ b/src/main/java/kr/pickple/back/address/dto/kakao/KakaoAddressResponse.java
@@ -1,0 +1,30 @@
+package kr.pickple.back.address.dto.kakao;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KakaoAddressResponse {
+
+    private List<Document> documents;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    static class Document {
+
+        private String addressName;
+        private Double x;
+        private Double y;
+    }
+
+    public Coordinate toCoordinate() {
+        return Coordinate.builder()
+                .x(documents.get(0).x)
+                .y(documents.get(0).y)
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/address/service/kakao/KakaoAddressSearchApiClient.java
+++ b/src/main/java/kr/pickple/back/address/service/kakao/KakaoAddressSearchApiClient.java
@@ -1,0 +1,19 @@
+package kr.pickple.back.address.service.kakao;
+
+import static org.springframework.http.HttpHeaders.*;
+
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+
+import kr.pickple.back.address.dto.kakao.KakaoAddressResponse;
+
+public interface KakaoAddressSearchApiClient {
+
+    @GetExchange
+    KakaoAddressResponse fetchAddress(
+            @RequestHeader(name = AUTHORIZATION) final String kakaoAK,
+            @RequestParam final MultiValueMap<String, String> params
+    );
+}

--- a/src/main/java/kr/pickple/back/address/service/kakao/KakaoAddressSearchClient.java
+++ b/src/main/java/kr/pickple/back/address/service/kakao/KakaoAddressSearchClient.java
@@ -1,0 +1,34 @@
+package kr.pickple.back.address.service.kakao;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import kr.pickple.back.address.dto.kakao.Coordinate;
+import kr.pickple.back.address.dto.kakao.KakaoAddressResponse;
+import kr.pickple.back.auth.config.property.KakaoOauthProperties;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAddressSearchClient {
+
+    private final KakaoAddressSearchApiClient kakaoAddressSearchApiClient;
+    private final KakaoOauthProperties kakaoOauthProperties;
+
+    public Coordinate fetchAddress(final String address) {
+        final KakaoAddressResponse kakaoAddressResponse = kakaoAddressSearchApiClient.fetchAddress(
+                "KakaoAK " + kakaoOauthProperties.getClientId(),
+                addressRequestParams(address)
+        );
+
+        return kakaoAddressResponse.toCoordinate();
+    }
+
+    private MultiValueMap<String, String> addressRequestParams(final String address) {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("query", address);
+
+        return params;
+    }
+}

--- a/src/main/java/kr/pickple/back/auth/config/property/KakaoOauthProperties.java
+++ b/src/main/java/kr/pickple/back/auth/config/property/KakaoOauthProperties.java
@@ -16,5 +16,6 @@ public class KakaoOauthProperties {
     private final String authUrl;
     private final String redirectUrl;
     private final String memberUrl;
+    private final String addressUrl;
     private final String providerUrl;
 }

--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -116,6 +116,8 @@ public class Game extends BaseEntity {
             final Integer cost,
             final Integer maxMemberCount,
             final Member host,
+            final Double latitude,
+            final Double longitude,
             final AddressDepth1 addressDepth1,
             final AddressDepth2 addressDepth2,
             final List<Position> positions
@@ -130,6 +132,8 @@ public class Game extends BaseEntity {
         this.cost = cost;
         this.maxMemberCount = maxMemberCount;
         this.host = host;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.addressDepth1 = addressDepth1;
         this.addressDepth2 = addressDepth2;
         updateGamePositions(positions);

--- a/src/main/java/kr/pickple/back/game/dto/request/GameCreateRequest.java
+++ b/src/main/java/kr/pickple/back/game/dto/request/GameCreateRequest.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import kr.pickple.back.address.dto.kakao.Coordinate;
 import kr.pickple.back.address.dto.response.MainAddressResponse;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.member.domain.Member;
@@ -65,7 +66,11 @@ public class GameCreateRequest {
     @NotNull(message = "포지션 목록은 null일 수 없음")
     private List<Position> positions;
 
-    public Game toEntity(final Member host, final MainAddressResponse mainAddressResponse) {
+    public Game toEntity(
+            final Member host,
+            final MainAddressResponse mainAddressResponse,
+            final Coordinate coordinate
+    ) {
         return Game.builder()
                 .content(content)
                 .playDate(playDate)
@@ -77,6 +82,8 @@ public class GameCreateRequest {
                 .cost(cost)
                 .maxMemberCount(maxMemberCount)
                 .host(host)
+                .latitude(coordinate.getY())
+                .longitude(coordinate.getX())
                 .addressDepth1(mainAddressResponse.getAddressDepth1())
                 .addressDepth2(mainAddressResponse.getAddressDepth2())
                 .positions(positions)

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -11,8 +11,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.pickple.back.address.dto.kakao.Coordinate;
 import kr.pickple.back.address.dto.response.MainAddressResponse;
 import kr.pickple.back.address.service.AddressService;
+import kr.pickple.back.address.service.kakao.KakaoAddressSearchClient;
 import kr.pickple.back.common.domain.RegistrationStatus;
 import kr.pickple.back.common.util.DateTimeUtil;
 import kr.pickple.back.game.domain.Category;
@@ -41,14 +43,17 @@ public class GameService {
     private final GameRepository gameRepository;
     private final GameMemberRepository gameMemberRepository;
     private final MemberRepository memberRepository;
+    private final KakaoAddressSearchClient kakaoAddressSearchClient;
 
     @Transactional
     public GameIdResponse createGame(final GameCreateRequest gameCreateRequest, final Long loggedInMemberId) {
         final Member host = findMemberById(loggedInMemberId);
+        final Coordinate coordinate = kakaoAddressSearchClient.fetchAddress(
+                gameCreateRequest.getMainAddress());
         final MainAddressResponse mainAddressResponse = addressService.findMainAddressByAddressStrings(
                 gameCreateRequest.getMainAddress());
 
-        final Game game = gameCreateRequest.toEntity(host, mainAddressResponse);
+        final Game game = gameCreateRequest.toEntity(host, mainAddressResponse, coordinate);
         final Game savedGame = gameRepository.save(game);
         savedGame.addGameMember(host);
 


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 게스트 모집 생성에서 받은 상세 주소를 -> 좌표 값으로 변환하는 API를 구현한다.
- 변환된 좌표를 Game 도메인 저장시 추가하여 저장하도록 로직을 변경한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] Kakao쪽으로 Address API 요청 로직 작성
- [X] KakaoOauthProperties에 API 요청 주소 추가
- [X] createGame에 관련 API 요청 추가하여 Game 도메인에 좌표 값 추가

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---
### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
