### PR TITLE
[#146] 특정 중심 좌표로부터 특정 거리 사이의 게스트 모집 글 조회 기능 구현

### DIFF
--- a/src/main/http/game/game.http
+++ b/src/main/http/game/game.http
@@ -67,3 +67,6 @@ Authorization:
 
 ### 조건별 게스트 모집글 조회(장소)
 GET http://localhost:8080/games?category=location&value=서울시+영등포구&page=0&size=3
+
+### 위도, 경도, 거리를 통해 해당하는 게스트 모집글 조회
+GET http://localhost:8080/games/locations?latitude=37.5066680941127&longitude=126.897412723839&distance=10

--- a/src/main/java/kr/pickple/back/game/controller/GameController.java
+++ b/src/main/java/kr/pickple/back/game/controller/GameController.java
@@ -126,4 +126,14 @@ public class GameController {
         return ResponseEntity.status(NO_CONTENT)
                 .build();
     }
+
+    @GetMapping("/locations")
+    public ResponseEntity<List<GameResponse>> findGamesWithInDistance(
+            @RequestParam final Double latitude,
+            @RequestParam final Double longitude,
+            @RequestParam final Double distance
+    ) {
+        return ResponseEntity.status(OK)
+                .body(gameService.findGamesWithInDistance(latitude, longitude, distance));
+    }
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameRepository.java
@@ -1,8 +1,12 @@
 package kr.pickple.back.game.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kr.pickple.back.address.domain.AddressDepth1;
 import kr.pickple.back.address.domain.AddressDepth2;
@@ -10,6 +14,16 @@ import kr.pickple.back.game.domain.Game;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
+    String HAVERSINE_FORMULA = "(6371 * acos(cos(radians(:latitude)) * cos(radians(g.latitude)) *" +
+            " cos(radians(g.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(g.latitude))))";
+
     Page<Game> findByAddressDepth1AndAddressDepth2(final AddressDepth1 addressDepth1, final AddressDepth2 addressDepth2,
             final Pageable pageable);
+
+    @Query("SELECT g FROM Game g WHERE " + HAVERSINE_FORMULA + " < :distance ORDER BY " + HAVERSINE_FORMULA)
+    List<Game> findGamesWithInDistance(
+            @Param("latitude") final Double latitude,
+            @Param("longitude") final Double longitude,
+            @Param("distance") final Double distanceWithInKm
+    );
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import kr.pickple.back.address.domain.AddressDepth1;
 import kr.pickple.back.address.domain.AddressDepth2;
@@ -22,8 +21,8 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     @Query("SELECT g FROM Game g WHERE " + HAVERSINE_FORMULA + " < :distance ORDER BY " + HAVERSINE_FORMULA)
     List<Game> findGamesWithInDistance(
-            @Param("latitude") final Double latitude,
-            @Param("longitude") final Double longitude,
-            @Param("distance") final Double distanceWithInKm
+            final Double latitude,
+            final Double longitude,
+            final Double distance
     );
 }

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -241,4 +241,16 @@ public class GameService {
                 .findFirst()
                 .orElseThrow(() -> new GameException(GAME_MEMBER_NOT_FOUND, reviewedMemberId));
     }
+
+    public List<GameResponse> findGamesWithInDistance(
+            final Double latitude,
+            final Double longitude,
+            final Double distance
+    ) {
+        final List<Game> games = gameRepository.findGamesWithInDistance(latitude, longitude, distance);
+
+        return games.stream()
+                .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
+                .toList();
+    }
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 클라이언트의 지도 페이지에서 실시간 위치 또는 특정 중심 좌표로부터 특정 거리 사이의 게스트 모집 글들을 조회한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] Repository에 하버사인 공식 적용한 쿼리문 작성, Controller, Service 구현
- [X] game.http에 예시 추가

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 현재는 MySQL의 연산 함수를 이용해서 처리하고 있으나 추후 고도화하여 Point 자료형으로 변환할 예정입니다.

<!-- 이슈와 관련된 데이터를 나열 -->
### 📀 관련 데이터 (화면, 테이블, API 등)
#### 화면
<img src="https://github.com/Java-and-Script/pickple-back/assets/92444744/c92647ec-4d99-4102-908f-dee0a6e7261d" width=200px height=400px />


#### 테이블 명
- game


#### API endpoint
- `GET` /games/locations?latitude={latitude}&longitude={longitude}&distance={distance}


---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
