### PR TITLE
[#148] RequestMapping 경로 겹치는 현상 문제 해결

### DIFF
--- a/src/main/java/kr/pickple/back/game/controller/GameController.java
+++ b/src/main/java/kr/pickple/back/game/controller/GameController.java
@@ -127,7 +127,7 @@ public class GameController {
                 .build();
     }
 
-    @GetMapping("/locations")
+    @GetMapping("/by-location")
     public ResponseEntity<List<GameResponse>> findGamesWithInDistance(
             @RequestParam final Double latitude,
             @RequestParam final Double longitude,


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- /games/{gameId} 와 /games/locations의 겹치는 Mapping으로 인한 배포서버에서 에러 발생

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [ ] Controller API Mapping 명 변경

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
