### PR TITLE
[#152] 거리별 게스트 모집 조회 기능 동적 쿼리를 위한 QueryDSL 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     implementation group: 'org.flywaydb', name: 'flyway-mysql', version: '9.10.2'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'io.jsonwebtoken:jjwt-api:0.12.1'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.1'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.1'

--- a/src/main/java/kr/pickple/back/common/config/JpaConfig.java
+++ b/src/main/java/kr/pickple/back/common/config/JpaConfig.java
@@ -1,10 +1,23 @@
 package kr.pickple.back.common.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableJpaAuditing
+@RequiredArgsConstructor
 public class JpaConfig {
 
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(final EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameRepository.java
@@ -1,29 +1,15 @@
 package kr.pickple.back.game.repository;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import kr.pickple.back.address.domain.AddressDepth1;
 import kr.pickple.back.address.domain.AddressDepth2;
 import kr.pickple.back.game.domain.Game;
 
-public interface GameRepository extends JpaRepository<Game, Long> {
+public interface GameRepository extends JpaRepository<Game, Long>, GameSearchRepository {
 
     Page<Game> findByAddressDepth1AndAddressDepth2(final AddressDepth1 addressDepth1, final AddressDepth2 addressDepth2,
             final Pageable pageable);
-
-    @Query("SELECT g "
-            + "FROM Game g  "
-            + "WHERE ST_Contains(ST_Buffer(ST_GeomFromText(CONCAT('POINT(', :latitude, ' ', :longitude, ')'), 4326), :distance), g.point)"
-            + "ORDER BY ST_Distance_Sphere(g.point, ST_GeomFromText(CONCAT('POINT(', :latitude, ' ', :longitude, ')'), 4326))"
-    )
-    List<Game> findGamesWithInDistance(
-            final Double latitude,
-            final Double longitude,
-            final Double distance
-    );
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
@@ -1,53 +1,10 @@
 package kr.pickple.back.game.repository;
 
-import static kr.pickple.back.game.domain.QGame.*;
-
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
-
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import kr.pickple.back.game.domain.Game;
-import lombok.RequiredArgsConstructor;
 
-@Repository
-@RequiredArgsConstructor
-public class GameSearchRepository {
+public interface GameSearchRepository {
 
-    private final JPAQueryFactory jpaQueryFactory;
-
-    public List<Game> findGamesWithInDistance(
-            final Double latitude,
-            final Double longitude,
-            final Double distance
-    ) {
-        final String pointWKT = String.format("POINT(%s %s)", latitude, longitude);
-
-        return jpaQueryFactory
-                .selectFrom(game)
-                .where(isWithInDistance(pointWKT, distance))
-                .orderBy(getOrderByDistance(pointWKT))
-                .fetch();
-    }
-
-    public BooleanExpression isWithInDistance(final String pointWKT, final Double distance) {
-        return Expressions.booleanTemplate(
-                "ST_Contains(ST_Buffer(ST_GeomFromText({0}, 4326), {1}), point)",
-                pointWKT,
-                distance
-        );
-    }
-
-    public OrderSpecifier<Double> getOrderByDistance(final String pointWKT) {
-        return Expressions.numberTemplate(
-                        Double.class,
-                        "ST_Distance_Sphere(point, ST_GeomFromText({0}, 4326))",
-                        pointWKT
-                )
-                .asc();
-    }
+    List<Game> findGamesWithInDistance(final Double latitude, final Double longitude, final Double distance);
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
@@ -1,0 +1,53 @@
+package kr.pickple.back.game.repository;
+
+import static kr.pickple.back.game.domain.QGame.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.pickple.back.game.domain.Game;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class GameSearchRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Game> findGamesWithInDistance(
+            final Double latitude,
+            final Double longitude,
+            final Double distance
+    ) {
+        final String pointWKT = String.format("POINT(%s %s)", latitude, longitude);
+
+        return jpaQueryFactory
+                .selectFrom(game)
+                .where(isWithInDistance(pointWKT, distance))
+                .orderBy(getOrderByDistance(pointWKT))
+                .fetch();
+    }
+
+    public BooleanExpression isWithInDistance(final String pointWKT, final Double distance) {
+        return Expressions.booleanTemplate(
+                "ST_Contains(ST_Buffer(ST_GeomFromText({0}, 4326), {1}), point)",
+                pointWKT,
+                distance
+        );
+    }
+
+    public OrderSpecifier<Double> getOrderByDistance(final String pointWKT) {
+        return Expressions.numberTemplate(
+                        Double.class,
+                        "ST_Distance_Sphere(point, ST_GeomFromText({0}, 4326))",
+                        pointWKT
+                )
+                .asc();
+    }
+}

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
@@ -1,0 +1,50 @@
+package kr.pickple.back.game.repository;
+
+import static kr.pickple.back.game.domain.QGame.*;
+
+import java.util.List;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.pickple.back.game.domain.Game;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GameSearchRepositoryImpl implements GameSearchRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Game> findGamesWithInDistance(
+            final Double latitude,
+            final Double longitude,
+            final Double distance
+    ) {
+        final String pointWKT = String.format("POINT(%s %s)", latitude, longitude);
+
+        return jpaQueryFactory
+                .selectFrom(game)
+                .where(isWithInDistance(pointWKT, distance))
+                .orderBy(getOrderByDistance(pointWKT))
+                .fetch();
+    }
+
+    private BooleanExpression isWithInDistance(final String pointWKT, final Double distance) {
+        return Expressions.booleanTemplate(
+                "ST_Contains(ST_Buffer(ST_GeomFromText({0}, 4326), {1}), point)",
+                pointWKT,
+                distance
+        );
+    }
+
+    private OrderSpecifier<Double> getOrderByDistance(final String pointWKT) {
+        return Expressions.numberTemplate(
+                        Double.class,
+                        "ST_Distance_Sphere(point, ST_GeomFromText({0}, 4326))",
+                        pointWKT
+                )
+                .asc();
+    }
+}

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -28,6 +28,7 @@ import kr.pickple.back.game.dto.response.GameResponse;
 import kr.pickple.back.game.exception.GameException;
 import kr.pickple.back.game.repository.GameMemberRepository;
 import kr.pickple.back.game.repository.GameRepository;
+import kr.pickple.back.game.repository.GameSearchRepository;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.dto.response.MemberResponse;
 import kr.pickple.back.member.exception.MemberException;
@@ -44,6 +45,7 @@ public class GameService {
     private final GameMemberRepository gameMemberRepository;
     private final MemberRepository memberRepository;
     private final KakaoAddressSearchClient kakaoAddressSearchClient;
+    private final GameSearchRepository gameSearchRepository;
 
     @Transactional
     public GameIdResponse createGame(final GameCreateRequest gameCreateRequest, final Long loggedInMemberId) {
@@ -252,7 +254,7 @@ public class GameService {
             final Double longitude,
             final Double distance
     ) {
-        final List<Game> games = gameRepository.findGamesWithInDistance(latitude, longitude, distance);
+        final List<Game> games = gameSearchRepository.findGamesWithInDistance(latitude, longitude, distance);
 
         return games.stream()
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -28,7 +28,6 @@ import kr.pickple.back.game.dto.response.GameResponse;
 import kr.pickple.back.game.exception.GameException;
 import kr.pickple.back.game.repository.GameMemberRepository;
 import kr.pickple.back.game.repository.GameRepository;
-import kr.pickple.back.game.repository.GameSearchRepository;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.dto.response.MemberResponse;
 import kr.pickple.back.member.exception.MemberException;
@@ -45,7 +44,6 @@ public class GameService {
     private final GameMemberRepository gameMemberRepository;
     private final MemberRepository memberRepository;
     private final KakaoAddressSearchClient kakaoAddressSearchClient;
-    private final GameSearchRepository gameSearchRepository;
 
     @Transactional
     public GameIdResponse createGame(final GameCreateRequest gameCreateRequest, final Long loggedInMemberId) {
@@ -254,7 +252,7 @@ public class GameService {
             final Double longitude,
             final Double distance
     ) {
-        final List<Game> games = gameSearchRepository.findGamesWithInDistance(latitude, longitude, distance);
+        final List<Game> games = gameRepository.findGamesWithInDistance(latitude, longitude, distance);
 
         return games.stream()
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 거리별 게스트 모집 조회 기능을 기존 JPQL에서 QueryDSL로 변경하여 적용한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] build.gradle에 QueryDSL 관련 의존성 추가
- [X] JPQL -> QueryDSL로 변경

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- PR Merge 후 fetch join과 batch size 조절을 통한 성능 최적화 예정입니다.

---
<!-- 이슈와 관련된 데이터를 나열 -->
### 📀 관련 데이터 (화면, 테이블, API 등)
#### 화면
<img src="https://github.com/Java-and-Script/pickple-back/assets/92444744/c92647ec-4d99-4102-908f-dee0a6e7261d" width=200px height=400px />


#### 테이블 명
- game


#### API endpoint
- `GET` /games/by-location?latitude={latitude}&longitude={longitude}&distance={distance}
---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
