### PR TITLE
[#156] 거리별 게스트 모집 조회 기능 fetch join, batch size를 통한 쿼리 최적화 및 성능 개선

### DIFF
--- a/src/main/java/kr/pickple/back/game/domain/GamePositions.java
+++ b/src/main/java/kr/pickple/back/game/domain/GamePositions.java
@@ -5,6 +5,8 @@ import static kr.pickple.back.game.exception.GameExceptionCode.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
@@ -14,6 +16,7 @@ import kr.pickple.back.position.domain.Position;
 @Embeddable
 public class GamePositions {
 
+    @BatchSize(size = 1000)
     @OneToMany(mappedBy = "game", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<GamePosition> gamePositions = new ArrayList<>();
 

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
@@ -26,6 +26,10 @@ public class GameSearchRepositoryImpl implements GameSearchRepository {
 
         return jpaQueryFactory
                 .selectFrom(game)
+                .join(game.host).fetchJoin()
+                .join(game.addressDepth1).fetchJoin()
+                .join(game.addressDepth2).fetchJoin()
+                .leftJoin(game.gameMembers.gameMembers).fetchJoin()
                 .where(isWithInDistance(pointWKT, distance))
                 .orderBy(getOrderByDistance(pointWKT))
                 .fetch();

--- a/src/main/java/kr/pickple/back/member/domain/MemberPositions.java
+++ b/src/main/java/kr/pickple/back/member/domain/MemberPositions.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
@@ -15,6 +17,7 @@ import kr.pickple.back.position.domain.Position;
 @Embeddable
 public class MemberPositions {
 
+    @BatchSize(size = 1000)
     @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<MemberPosition> memberPositions = new ArrayList<>();
 


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 특정 좌표로 부터 특정 거리(M)까지의 게스트 모집글을 조회할 때 발생하는 N+1 문제를 해결한다.
- DTO에서 Entity로 변환할 때 get으로 가져오는 필드가 Lazy Loading으로 되어있어 N+1 문제가 지속적으로 발생
  - fetch join을 통하여 한 번에 select하여 가져올 수 있다.
  - `@OneToMany`가 2개 이상 있을 시 fetch join으로도 처리가 불가능하여 batch size를 적용하여 in으로 가져올 수 있도록 한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] fetch join 적용
- [X] batch size 적용

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- **적용 전** API 요청 시간 
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/b81677d9-617f-4501-a940-144af6644e71)
**2389개** 불러오는데 걸린시간: `1531ms`

- **적용 후** API 요청 시간
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/93277cb5-802d-45b1-ad3b-2dbf6a394bd8)
**2389개** 불러오는데 걸린시간: `323ms`

`1531ms` -> `323ms` 약 5배 개선

- **fetch join 적용 전**
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/9c992ae3-61fe-45c8-98ff-396e0b31828f)

- **fetch join 적용 후**
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/dc0906ff-3c9b-4293-a0bf-79aa54466809)

- **batch size 적용 전**
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/00e43a51-2590-487f-984b-7920b343535a)

- **batch size 적용 후**
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/cf8140bc-c4ef-4ff9-b1ce-2d7be9ac3ffa)


---

<!-- 이슈와 관련된 데이터를 나열 -->
### 📀 관련 데이터 (화면, 테이블, API 등)
#### 화면
<img src="https://github.com/Java-and-Script/pickple-back/assets/92444744/c92647ec-4d99-4102-908f-dee0a6e7261d" width=200px height=400px />


#### 테이블 명
- game


#### API endpoint
- `GET` /games/by-location?latitude={latitude}&longitude={longitude}&distance={distance}

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
