### PR TITLE
[#160] 위치수집 동의를 하지 않은 사용자에게 특정 지역의 게스트 모집글을 보여주는 기능

### DIFF
--- a/src/main/java/kr/pickple/back/game/controller/GameController.java
+++ b/src/main/java/kr/pickple/back/game/controller/GameController.java
@@ -136,4 +136,13 @@ public class GameController {
         return ResponseEntity.status(OK)
                 .body(gameService.findGamesWithInDistance(latitude, longitude, distance));
     }
+
+    @GetMapping("/by-address")
+    public ResponseEntity<List<GameResponse>> findGamesWithInAddress(
+            @RequestParam final String addressDepth1,
+            @RequestParam final String addressDepth2
+    ) {
+        return ResponseEntity.status(OK)
+                .body(gameService.findGamesWithInAddress(addressDepth1, addressDepth2));
+    }
 }

--- a/src/main/java/kr/pickple/back/game/domain/GameMembers.java
+++ b/src/main/java/kr/pickple/back/game/domain/GameMembers.java
@@ -5,6 +5,8 @@ import static kr.pickple.back.game.exception.GameExceptionCode.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
@@ -17,6 +19,7 @@ import lombok.Getter;
 public class GameMembers {
 
     @Getter
+    @BatchSize(size = 1000)
     @OneToMany(mappedBy = "game", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<GameMember> gameMembers = new ArrayList<>();
 

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
@@ -2,9 +2,13 @@ package kr.pickple.back.game.repository;
 
 import java.util.List;
 
+import kr.pickple.back.address.domain.AddressDepth1;
+import kr.pickple.back.address.domain.AddressDepth2;
 import kr.pickple.back.game.domain.Game;
 
 public interface GameSearchRepository {
 
     List<Game> findGamesWithInDistance(final Double latitude, final Double longitude, final Double distance);
+
+    List<Game> findGamesWithInAddress(final AddressDepth1 addressDepth1, final AddressDepth2 addressDepth2);
 }

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -258,4 +258,19 @@ public class GameService {
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
                 .toList();
     }
+
+    public List<GameResponse> findGamesWithInAddress(
+            final String addressDepth1,
+            final String addressDepth2
+    ) {
+        final MainAddressResponse mainAddressResponse = addressService.findMainAddressByNames(addressDepth1,
+                addressDepth2);
+
+        final List<Game> games = gameRepository.findGamesWithInAddress(mainAddressResponse.getAddressDepth1(),
+                mainAddressResponse.getAddressDepth2());
+
+        return games.stream()
+                .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
+                .toList();
+    }
 }

--- a/src/main/java/kr/pickple/back/map/domain/MapPolygon.java
+++ b/src/main/java/kr/pickple/back/map/domain/MapPolygon.java
@@ -1,0 +1,48 @@
+package kr.pickple.back.map.domain;
+
+import java.math.BigDecimal;
+
+import org.locationtech.jts.geom.Polygon;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.pickple.back.address.domain.AddressDepth1;
+import kr.pickple.back.address.domain.AddressDepth2;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MapPolygon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_depth1_id")
+    private AddressDepth1 addressDepth1;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_depth2_id")
+    private AddressDepth2 addressDepth2;
+
+    @NotNull
+    private BigDecimal latitude;
+
+    @NotNull
+    private BigDecimal longitude;
+
+    @NotNull
+    private Polygon polygon;
+}


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 위치수집 동의를 하지 않은 경우 사용자의 위치를 기반으로 게스트 모집글을 불러올 수 없음.
- 회원가입시 받았던 주 활동지역을 기반으로 서버에 요청하여 특정 지역(서울시 영등포구)안에 있는 게스트 모집글을 보여주는 기능을 구현한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] Polygon 데이터 UTM-K에서 WGS84로 변환 (python으로 작업)
   - [관련 정리 내용](https://www.notion.so/backend-devcourse/Polygon-2b69daf245594ee69218590c55d1d6c7?pvs=4)
- [X] Polygon 데이터 MySQL에 INSERT
- [X] Polygon 도메인 생성
- [X] API 구현

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 추후 정렬 기준과 반환 값을 변경(각 구별로 중심좌표 추가)하여 클라이언트에서 조금 더 편하게 볼 수 있게 할 예정입니다.

---
#### 테이블 명
- map_polygon


#### API endpoint
- `GET` games/by-address?addressDepth1={addressDepth1}&addressDepth2={addressDepth2}

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
