### PR TITLE
[#163] 채팅 도메인 ERD 설계 및 엔티티 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.1'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.1'
 
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:stomp-websocket:2.3.4'
+    implementation 'org.webjars:sockjs-client:1.5.1'
+
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/kr/pickple/back/chat/domain/ChatMessage.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatMessage.java
@@ -1,0 +1,62 @@
+package kr.pickple.back.chat.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.pickple.back.chat.util.MessageTypeAttributeConverter;
+import kr.pickple.back.common.domain.BaseEntity;
+import kr.pickple.back.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @NotNull
+    @Convert(converter = MessageTypeAttributeConverter.class)
+    private MessageType type;
+
+    @Getter
+    @NotNull
+    @Column(length = 500)
+    private String content;
+
+    @Getter
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private Member sender;
+
+    @Getter
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @Builder
+    private ChatMessage(final ChatRoom chatRoom, final Member sender, final String content, final MessageType type) {
+        this.type = type;
+        this.content = content;
+        this.chatRoom = chatRoom;
+        this.sender = sender;
+    }
+
+    public void updateContent(final String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/domain/ChatMessages.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatMessages.java
@@ -1,0 +1,25 @@
+package kr.pickple.back.chat.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+
+@Embeddable
+public class ChatMessages {
+
+    @Getter
+    @OneToMany(mappedBy = "chatRoom", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
+
+    void addChatMessage(final ChatMessage chatMessage) {
+        chatMessages.add(chatMessage);
+    }
+
+    ChatMessage getLastChatMessage() {
+        return chatMessages.get(chatMessages.size() - 1);
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/domain/ChatRoom.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatRoom.java
@@ -1,0 +1,134 @@
+package kr.pickple.back.chat.domain;
+
+import static kr.pickple.back.chat.exception.ChatExceptionCode.*;
+
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import kr.pickple.back.chat.exception.ChatException;
+import kr.pickple.back.chat.util.RoomTypeAttributeConverter;
+import kr.pickple.back.common.domain.BaseEntity;
+import kr.pickple.back.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @Getter
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @NotNull
+    @Column(length = 20)
+    private String name;
+
+    @Getter
+    @NotNull
+    @Convert(converter = RoomTypeAttributeConverter.class)
+    private RoomType type;
+
+    @Getter
+    @NotNull
+    private Integer memberCount = 0;
+
+    @Getter
+    @NotNull
+    private Integer maxMemberCount = 2;
+
+    @Embedded
+    private ChatRoomMembers chatRoomMembers = new ChatRoomMembers();
+
+    @Embedded
+    private ChatMessages chatMessages = new ChatMessages();
+
+    @Builder
+    private ChatRoom(final String name, final RoomType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public void increaseMemberCount() {
+        if (isFullRoom()) {
+            throw new ChatException(CHAT_ROOM_IS_FULL, memberCount);
+        }
+
+        memberCount += 1;
+    }
+
+    private Boolean isFullRoom() {
+        return memberCount.equals(maxMemberCount);
+    }
+
+    public void decreaseMemberCount() {
+        if (isEmptyRoom()) {
+            throw new ChatException(CHAT_ROOM_IS_EMPTY, memberCount);
+        }
+
+        memberCount -= 1;
+    }
+
+    public Boolean isEmptyRoom() {
+        return memberCount == 0;
+    }
+
+    public Boolean isEntered(final Member member) {
+        return chatRoomMembers.isMemberEnteredRoom(member);
+    }
+
+    public Boolean isMatchedRoomType(final RoomType type) {
+        return this.type == type;
+    }
+
+    public void updateMaxMemberCount(final Integer maxMemberCount) {
+        if (maxMemberCount < memberCount) {
+            throw new ChatException(CHAT_MAX_MEMBER_COUNT_SHOULD_BE_BIGGER_THAN_MEMBER_COUNT, maxMemberCount);
+        }
+
+        this.maxMemberCount = maxMemberCount;
+    }
+
+    public void sendMessage(final ChatMessage chatMessage) {
+        chatMessages.addChatMessage(chatMessage);
+    }
+
+    public void enterNewMember(final ChatMessage chatMessage) {
+        final Member newMember = chatMessage.getSender();
+        chatRoomMembers.addChatRoomMember(this, newMember);
+
+        sendMessage(chatMessage);
+        increaseMemberCount();
+    }
+
+    public void leaveRoom(final ChatMessage chatMessage) {
+        final Member member = chatMessage.getSender();
+        chatRoomMembers.removeChatRoomMember(this, member);
+
+        sendMessage(chatMessage);
+        decreaseMemberCount();
+    }
+
+    public List<ChatMessage> getChatMessages() {
+        return chatMessages.getChatMessages();
+    }
+
+    public List<Member> getMembersInRoom() {
+        return chatRoomMembers.getMembers();
+    }
+
+    public ChatMessage getLastChatMessage() {
+        return chatMessages.getLastChatMessage();
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/domain/ChatRoomMember.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatRoomMember.java
@@ -1,0 +1,48 @@
+package kr.pickple.back.chat.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import kr.pickple.back.common.domain.BaseEntity;
+import kr.pickple.back.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "chat_room_id"}))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"member", "chatRoom"}, callSuper = false)
+public class ChatRoomMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Getter
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @Builder
+    private ChatRoomMember(final Member member, final ChatRoom chatRoom) {
+        this.member = member;
+        this.chatRoom = chatRoom;
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/domain/ChatRoomMembers.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatRoomMembers.java
@@ -1,0 +1,44 @@
+package kr.pickple.back.chat.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import kr.pickple.back.member.domain.Member;
+
+@Embeddable
+public class ChatRoomMembers {
+
+    @OneToMany(mappedBy = "chatRoom", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    private List<ChatRoomMember> chatRoomMembers = new ArrayList<>();
+
+    void addChatRoomMember(final ChatRoom chatRoom, final Member member) {
+        final ChatRoomMember chatRoomMember = buildChatRoom(chatRoom, member);
+        chatRoomMembers.add(chatRoomMember);
+    }
+
+    void removeChatRoomMember(final ChatRoom chatRoom, final Member member) {
+        final ChatRoomMember chatRoomMember = buildChatRoom(chatRoom, member);
+        chatRoomMembers.remove(chatRoomMember);
+    }
+
+    Boolean isMemberEnteredRoom(final Member member) {
+        return chatRoomMembers.stream()
+                .anyMatch(chatRoomMember -> member.equals(chatRoomMember.getMember()));
+    }
+
+    List<Member> getMembers() {
+        return chatRoomMembers.stream()
+                .map(ChatRoomMember::getMember)
+                .toList();
+    }
+
+    private ChatRoomMember buildChatRoom(final ChatRoom chatRoom, final Member member) {
+        return ChatRoomMember.builder()
+                .member(member)
+                .chatRoom(chatRoom)
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/domain/MessageType.java
+++ b/src/main/java/kr/pickple/back/chat/domain/MessageType.java
@@ -1,0 +1,50 @@
+package kr.pickple.back.chat.domain;
+
+import static kr.pickple.back.chat.exception.ChatExceptionCode.*;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import kr.pickple.back.chat.exception.ChatException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum MessageType {
+    ENTER("입장"),
+    TALK("대화"),
+    LEAVE("퇴장"),
+    ;
+
+    private static final String ENTER_MESSAGE_SUFFIX = "님이 채팅방에 입장하셨습니다.";
+    private static final String LEAVE_MESSAGE_SUFFIX = "님이 채팅방을 떠났습니다.";
+    private static final Map<String, MessageType> messageTypeMap = Collections.unmodifiableMap(
+            Stream.of(values()).collect(Collectors.toMap(MessageType::getDescription, Function.identity())));
+
+    @Getter
+    @JsonValue
+    private final String description;
+
+    @JsonCreator
+    public static MessageType from(final String description) {
+        if (messageTypeMap.containsKey(description)) {
+            return messageTypeMap.get(description);
+        }
+
+        throw new ChatException(CHAT_MESSAGE_TYPE_NOT_FOUND, description);
+    }
+
+    public static String makeEnterMessage(final String nickname) {
+        return nickname + ENTER_MESSAGE_SUFFIX;
+    }
+
+    public static String makeLeaveMessage(final String nickname) {
+        return nickname + LEAVE_MESSAGE_SUFFIX;
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/domain/RoomType.java
+++ b/src/main/java/kr/pickple/back/chat/domain/RoomType.java
@@ -1,0 +1,40 @@
+package kr.pickple.back.chat.domain;
+
+import static kr.pickple.back.chat.exception.ChatExceptionCode.*;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import kr.pickple.back.chat.exception.ChatException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RoomType {
+    PERSONAL("개인"),
+    GAME("게스트"),
+    CREW("크루"),
+    ;
+
+    private static final Map<String, RoomType> roomTypeMap = Collections.unmodifiableMap(
+            Stream.of(values()).collect(Collectors.toMap(RoomType::getDescription, Function.identity())));
+
+    @Getter
+    @JsonValue
+    private final String description;
+
+    @JsonCreator
+    public static RoomType from(final String description) {
+        if (roomTypeMap.containsKey(description)) {
+            return roomTypeMap.get(description);
+        }
+
+        throw new ChatException(CHAT_ROOM_TYPE_NOT_FOUND, description);
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/dto/request/ChatMessageCreateRequest.java
+++ b/src/main/java/kr/pickple/back/chat/dto/request/ChatMessageCreateRequest.java
@@ -1,0 +1,20 @@
+package kr.pickple.back.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageCreateRequest {
+
+    @NotNull(message = "송신자 ID가 입력되지 않음")
+    @Positive(message = "송신자 ID는 1이상의 자연수로 입력해야함")
+    private Long senderId;
+
+    @NotBlank(message = "채팅 메시지의 내용이 입력되지 않음")
+    private String content;
+}

--- a/src/main/java/kr/pickple/back/chat/dto/request/PersonalChatRoomCreateRequest.java
+++ b/src/main/java/kr/pickple/back/chat/dto/request/PersonalChatRoomCreateRequest.java
@@ -1,0 +1,16 @@
+package kr.pickple.back.chat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalChatRoomCreateRequest {
+
+    @NotNull(message = "수신자 ID가 입력되지 않음")
+    @Positive(message = "수신자 ID는 1이상의 자연수로 입력해야함")
+    private Long receiverId;
+}

--- a/src/main/java/kr/pickple/back/chat/dto/response/ChatMemberResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/ChatMemberResponse.java
@@ -1,0 +1,25 @@
+package kr.pickple.back.chat.dto.response;
+
+import kr.pickple.back.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMemberResponse {
+
+    private Long id;
+    private String nickname;
+    private String profileImageUrl;
+
+    public static ChatMemberResponse from(final Member member) {
+        return ChatMemberResponse.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,32 @@
+package kr.pickple.back.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import kr.pickple.back.chat.domain.ChatMessage;
+import kr.pickple.back.chat.domain.MessageType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessageResponse {
+
+    private MessageType type;
+    private String content;
+    private ChatMemberResponse sender;
+    private Long roomId;
+    private LocalDateTime createdAt;
+
+    public static ChatMessageResponse from(final ChatMessage chatMessage) {
+        return ChatMessageResponse.builder()
+                .type(chatMessage.getType())
+                .content(chatMessage.getContent())
+                .sender(ChatMemberResponse.from(chatMessage.getSender()))
+                .roomId(chatMessage.getChatRoom().getId())
+                .createdAt(chatMessage.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomDetailResponse.java
@@ -1,0 +1,83 @@
+package kr.pickple.back.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import kr.pickple.back.chat.domain.ChatRoom;
+import kr.pickple.back.chat.domain.RoomType;
+import kr.pickple.back.crew.domain.Crew;
+import kr.pickple.back.game.domain.Game;
+import kr.pickple.back.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatRoomDetailResponse {
+
+    private Long id;
+    private String roomName;
+    private String roomIconImageUrl;
+    private RoomType type;
+    private Long domainId;
+    private Integer memberCount;
+    private Integer maxMemberCount;
+    private LocalTime playStartTime;
+    private Integer playTimeMinutes;
+    private List<ChatMemberResponse> members;
+    private LocalDateTime createdAt;
+
+    public static ChatRoomDetailResponse of(final ChatRoom chatRoom, final Member receiver) {
+        return ChatRoomDetailResponse.builder()
+                .id(chatRoom.getId())
+                .roomName(receiver.getNickname())
+                .roomIconImageUrl(receiver.getProfileImageUrl())
+                .type(chatRoom.getType())
+                .domainId(receiver.getId())
+                .memberCount(chatRoom.getMemberCount())
+                .maxMemberCount(chatRoom.getMaxMemberCount())
+                .members(getChatMemberResponses(chatRoom))
+                .createdAt(chatRoom.getCreatedAt())
+                .build();
+    }
+
+    public static ChatRoomDetailResponse of(final ChatRoom chatRoom, final Game game) {
+        return ChatRoomDetailResponse.builder()
+                .id(chatRoom.getId())
+                .roomName(chatRoom.getName())
+                .type(chatRoom.getType())
+                .domainId(game.getId())
+                .memberCount(chatRoom.getMemberCount())
+                .maxMemberCount(chatRoom.getMaxMemberCount())
+                .playStartTime(game.getPlayStartTime())
+                .playTimeMinutes(game.getPlayTimeMinutes())
+                .members(getChatMemberResponses(chatRoom))
+                .createdAt(chatRoom.getCreatedAt())
+                .build();
+    }
+
+    public static ChatRoomDetailResponse of(final ChatRoom chatRoom, final Crew crew) {
+        return ChatRoomDetailResponse.builder()
+                .id(chatRoom.getId())
+                .roomName(chatRoom.getName())
+                .roomIconImageUrl(crew.getProfileImageUrl())
+                .type(chatRoom.getType())
+                .domainId(crew.getId())
+                .memberCount(chatRoom.getMemberCount())
+                .maxMemberCount(chatRoom.getMaxMemberCount())
+                .members(getChatMemberResponses(chatRoom))
+                .createdAt(chatRoom.getCreatedAt())
+                .build();
+    }
+
+    private static List<ChatMemberResponse> getChatMemberResponses(final ChatRoom chatRoom) {
+        return chatRoom.getMembersInRoom()
+                .stream()
+                .map(ChatMemberResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomExistedResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomExistedResponse.java
@@ -1,0 +1,11 @@
+package kr.pickple.back.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "from")
+public class ChatRoomExistedResponse {
+
+    private Boolean existed;
+}

--- a/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomResponse.java
@@ -1,0 +1,48 @@
+package kr.pickple.back.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import kr.pickple.back.chat.domain.RoomType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatRoomResponse {
+
+    private Long id;
+    private String roomName;
+    private String roomIconImageUrl;
+    private RoomType type;
+    private Integer memberCount;
+    private Integer maxMemberCount;
+    private LocalTime playStartTime;
+    private Integer playTimeMinutes;
+    private String lastMessageContent;
+    private LocalDateTime lastMessageCreatedAt;
+    private LocalDateTime createdAt;
+
+    public static ChatRoomResponse of(
+            final ChatRoomDetailResponse chatRoomDetail,
+            final String lastMessageContent,
+            final LocalDateTime lastMessageCreatedAt
+    ) {
+        return ChatRoomResponse.builder()
+                .id(chatRoomDetail.getId())
+                .roomName(chatRoomDetail.getRoomName())
+                .roomIconImageUrl(chatRoomDetail.getRoomIconImageUrl())
+                .type(chatRoomDetail.getType())
+                .memberCount(chatRoomDetail.getMemberCount())
+                .maxMemberCount(chatRoomDetail.getMaxMemberCount())
+                .playStartTime(chatRoomDetail.getPlayStartTime())
+                .playTimeMinutes(chatRoomDetail.getPlayTimeMinutes())
+                .lastMessageContent(lastMessageContent)
+                .lastMessageCreatedAt(lastMessageCreatedAt)
+                .createdAt(chatRoomDetail.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/exception/ChatException.java
+++ b/src/main/java/kr/pickple/back/chat/exception/ChatException.java
@@ -1,0 +1,11 @@
+package kr.pickple.back.chat.exception;
+
+import kr.pickple.back.common.exception.BusinessException;
+import kr.pickple.back.common.exception.ExceptionCode;
+
+public class ChatException extends BusinessException {
+
+    public ChatException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
+        super(exceptionCode, rejectedValues);
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/exception/ChatExceptionCode.java
+++ b/src/main/java/kr/pickple/back/chat/exception/ChatExceptionCode.java
@@ -1,0 +1,27 @@
+package kr.pickple.back.chat.exception;
+
+import org.springframework.http.HttpStatus;
+
+import kr.pickple.back.common.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatExceptionCode implements ExceptionCode {
+
+    CHAT_MESSAGE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHT-001", "채팅 메시지 타입을 찾을 수 없음"),
+    CHAT_ROOM_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHT-002", "채팅방 타입을 찾을 수 없음"),
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHT-003", "채팅방을 찾을 수 없음"),
+    CHAT_ROOM_IS_FULL(HttpStatus.BAD_REQUEST, "CHT-004", "채팅방 인원이 가득참"),
+    CHAT_ROOM_IS_EMPTY(HttpStatus.NOT_FOUND, "CHT-005", "채팅방 인원이 비었음"),
+    CHAT_MEMBER_IS_ALREADY_IN_ROOM(HttpStatus.BAD_REQUEST, "CHT-006", "해당 채팅방에 이미 존재하는 사용자"),
+    CHAT_MEMBER_IS_NOT_IN_ROOM(HttpStatus.BAD_REQUEST, "CHT-007", "해당 채팅방에 존재하지 않는 사용자"),
+    CHAT_MEMBER_CANNOT_CHAT_SELF(HttpStatus.BAD_REQUEST, "CHT-008", "사용자는 자기 자신과 채팅할 수 없음"),
+    CHAT_MAX_MEMBER_COUNT_SHOULD_BE_BIGGER_THAN_MEMBER_COUNT(HttpStatus.BAD_REQUEST, "CHT-009", "채팅방 인원제한은 현재 인원수 이상이어야함"),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/pickple/back/chat/util/MessageTypeAttributeConverter.java
+++ b/src/main/java/kr/pickple/back/chat/util/MessageTypeAttributeConverter.java
@@ -1,0 +1,20 @@
+package kr.pickple.back.chat.util;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.persistence.AttributeConverter;
+import kr.pickple.back.chat.domain.MessageType;
+
+@Component
+public class MessageTypeAttributeConverter implements AttributeConverter<MessageType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final MessageType messageType) {
+        return messageType.getDescription();
+    }
+
+    @Override
+    public MessageType convertToEntityAttribute(final String description) {
+        return MessageType.from(description);
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/util/RoomTypeAttributeConverter.java
+++ b/src/main/java/kr/pickple/back/chat/util/RoomTypeAttributeConverter.java
@@ -1,0 +1,20 @@
+package kr.pickple.back.chat.util;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.persistence.AttributeConverter;
+import kr.pickple.back.chat.domain.RoomType;
+
+@Component
+public class RoomTypeAttributeConverter implements AttributeConverter<RoomType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final RoomType roomType) {
+        return roomType.getDescription();
+    }
+
+    @Override
+    public RoomType convertToEntityAttribute(final String description) {
+        return RoomType.from(description);
+    }
+}

--- a/src/main/java/kr/pickple/back/chat/util/RoomTypeConverter.java
+++ b/src/main/java/kr/pickple/back/chat/util/RoomTypeConverter.java
@@ -1,0 +1,15 @@
+package kr.pickple.back.chat.util;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import kr.pickple.back.chat.domain.RoomType;
+
+@Component
+public class RoomTypeConverter implements Converter<String, RoomType> {
+
+    @Override
+    public RoomType convert(final String description) {
+        return RoomType.from(description);
+    }
+}

--- a/src/main/java/kr/pickple/back/common/config/WebConfig.java
+++ b/src/main/java/kr/pickple/back/common/config/WebConfig.java
@@ -14,6 +14,7 @@ import kr.pickple.back.auth.config.OauthProviderConverter;
 import kr.pickple.back.auth.config.property.CorsProperties;
 import kr.pickple.back.auth.config.resolver.LoginTokenArgumentResolver;
 import kr.pickple.back.auth.config.resolver.RegisterTokenArgumentResolver;
+import kr.pickple.back.chat.util.RoomTypeConverter;
 import kr.pickple.back.common.util.RegistrationStatusConverter;
 import kr.pickple.back.game.util.CategoryConverter;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addConverter(new OauthProviderConverter());
         registry.addConverter(new RegistrationStatusConverter());
         registry.addConverter(new CategoryConverter());
+        registry.addConverter(new RoomTypeConverter());
     }
 
     @Override

--- a/src/main/java/kr/pickple/back/common/domain/BaseEntity.java
+++ b/src/main/java/kr/pickple/back/common/domain/BaseEntity.java
@@ -1,14 +1,18 @@
 package kr.pickple.back.common.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 채팅 기능에 대한 테이블 설계를 진행한다.
- 채팅 기능을 개발하기 위한 엔티티와 DTO 객체를 정의한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 채팅 테이블 정의
- [x] 채팅 도메인 엔티티 정의
- [x] 채팅 DTO 객체 정의
- [x] STOMP, SockJS 관련 의존성 추가

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
