### PR TITLE
[#168] 특정 지역의 게스트 모집글을 보여주는 기능 반환 값 및 정렬 기준 변경

### DIFF
--- a/src/main/java/kr/pickple/back/game/controller/GameController.java
+++ b/src/main/java/kr/pickple/back/game/controller/GameController.java
@@ -26,6 +26,7 @@ import kr.pickple.back.game.dto.request.MannerScoreReview;
 import kr.pickple.back.game.dto.request.MannerScoreReviewsRequest;
 import kr.pickple.back.game.dto.response.GameIdResponse;
 import kr.pickple.back.game.dto.response.GameResponse;
+import kr.pickple.back.game.dto.response.GamesAndLocationResponse;
 import kr.pickple.back.game.service.GameService;
 import lombok.RequiredArgsConstructor;
 
@@ -138,7 +139,7 @@ public class GameController {
     }
 
     @GetMapping("/by-address")
-    public ResponseEntity<List<GameResponse>> findGamesWithInAddress(
+    public ResponseEntity<GamesAndLocationResponse> findGamesWithInAddress(
             @RequestParam final String addressDepth1,
             @RequestParam final String addressDepth2
     ) {

--- a/src/main/java/kr/pickple/back/game/dto/response/GamesAndLocationResponse.java
+++ b/src/main/java/kr/pickple/back/game/dto/response/GamesAndLocationResponse.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GamesAndLocationResponse {
 
     private List<GameResponse> games;

--- a/src/main/java/kr/pickple/back/game/dto/response/GamesAndLocationResponse.java
+++ b/src/main/java/kr/pickple/back/game/dto/response/GamesAndLocationResponse.java
@@ -1,0 +1,48 @@
+package kr.pickple.back.game.dto.response;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import org.locationtech.jts.geom.Coordinate;
+
+import kr.pickple.back.map.domain.MapPolygon;
+import kr.pickple.back.map.dto.response.Location;
+import kr.pickple.back.map.dto.response.PolygonLocation;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GamesAndLocationResponse {
+
+    private List<GameResponse> games;
+    private Location location;
+    private List<PolygonLocation> polygon;
+
+    public static GamesAndLocationResponse of(final List<GameResponse> gameResponses, final MapPolygon polygon) {
+        final Location location = Location.builder()
+                .latitude(polygon.getLatitude())
+                .longitude(polygon.getLongitude())
+                .build();
+
+        final Coordinate[] coordinates = polygon.getPolygon().getCoordinates();
+
+        final List<PolygonLocation> polygonLocations = Arrays.stream(coordinates)
+                .map(data -> PolygonLocation.builder()
+                        .lat(BigDecimal.valueOf(data.y))
+                        .lng(BigDecimal.valueOf(data.x))
+                        .build()
+                )
+                .toList();
+
+        return GamesAndLocationResponse.builder()
+                .games(gameResponses)
+                .location(location)
+                .polygon(polygonLocations)
+                .build();
+    }
+}

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
@@ -10,5 +10,6 @@ public interface GameSearchRepository {
 
     List<Game> findGamesWithInDistance(final Double latitude, final Double longitude, final Double distance);
 
-    List<Game> findGamesWithInAddress(final AddressDepth1 addressDepth1, final AddressDepth2 addressDepth2);
+    List<Game> findGamesWithInAddress(final AddressDepth1 addressDepth1,
+            final AddressDepth2 addressDepth2);
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepository.java
@@ -10,6 +10,5 @@ public interface GameSearchRepository {
 
     List<Game> findGamesWithInDistance(final Double latitude, final Double longitude, final Double distance);
 
-    List<Game> findGamesWithInAddress(final AddressDepth1 addressDepth1,
-            final AddressDepth2 addressDepth2);
+    List<Game> findGamesWithInAddress(final AddressDepth1 addressDepth1, final AddressDepth2 addressDepth2);
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
@@ -91,9 +91,11 @@ public class GameSearchRepositoryImpl implements GameSearchRepository {
     }
 
     private OrderSpecifier<Double> getOrderByAddress() {
-        return Expressions.numberTemplate(Double.class,
+        return Expressions.numberTemplate(
+                        Double.class,
                         "ST_Distance_Sphere({0}, ST_GeomFromText('POINT(' || {1} || ' ' || {2} || ')', 4326))",
-                        game.point, mapPolygon.latitude, mapPolygon.longitude)
+                        game.point, mapPolygon.latitude, mapPolygon.longitude
+                )
                 .asc();
     }
 }

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
@@ -66,6 +66,7 @@ public class GameSearchRepositoryImpl implements GameSearchRepository {
                 .from(game)
                 .join(mapPolygon).on(isWithInAddress())
                 .where(isAddress(addressDepth1, addressDepth2))
+                .orderBy(getOrderByAddress())
                 .fetch();
     }
 
@@ -87,5 +88,12 @@ public class GameSearchRepositoryImpl implements GameSearchRepository {
 
     private BooleanExpression isAddressDepth2(final AddressDepth2 addressDepth2) {
         return mapPolygon.addressDepth2.eq(addressDepth2);
+    }
+
+    private OrderSpecifier<Double> getOrderByAddress() {
+        return Expressions.numberTemplate(Double.class,
+                        "ST_Distance_Sphere({0}, ST_GeomFromText('POINT(' || {1} || ' ' || {2} || ')', 4326))",
+                        game.point, mapPolygon.latitude, mapPolygon.longitude)
+                .asc();
     }
 }

--- a/src/main/java/kr/pickple/back/map/dto/response/Location.java
+++ b/src/main/java/kr/pickple/back/map/dto/response/Location.java
@@ -1,0 +1,17 @@
+package kr.pickple.back.map.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Location {
+
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+}

--- a/src/main/java/kr/pickple/back/map/dto/response/PolygonLocation.java
+++ b/src/main/java/kr/pickple/back/map/dto/response/PolygonLocation.java
@@ -1,0 +1,17 @@
+package kr.pickple.back.map.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PolygonLocation {
+
+    private BigDecimal lat;
+    private BigDecimal lng;
+}

--- a/src/main/java/kr/pickple/back/map/repository/MapPolygonRepository.java
+++ b/src/main/java/kr/pickple/back/map/repository/MapPolygonRepository.java
@@ -1,0 +1,13 @@
+package kr.pickple.back.map.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.pickple.back.address.domain.AddressDepth1;
+import kr.pickple.back.address.domain.AddressDepth2;
+import kr.pickple.back.map.domain.MapPolygon;
+
+public interface MapPolygonRepository extends JpaRepository<MapPolygon, Long> {
+
+    MapPolygon findByAddressDepth1AndAddressDepth2(final AddressDepth1 addressDepth1,
+            final AddressDepth2 addressDepth2);
+}


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 특정 지역의 게스트 모집글을 보여주는 기능에서 반환 값에 Polygon 데이터와 중심 좌표를 추가한다.
- 정렬되어있지 않은 게스트 모집글을 중심 좌표의 거리를 기준으로 산정하여 오름차순으로 정렬한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] 반환 값 추가 및 응답 값 변경
- [X] 중심 좌표로부터 제일 가까운 순으로 정렬하는 정렬 기능 추가

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---
<!-- 이슈와 관련된 데이터를 나열 -->
### 📀 관련 데이터 (화면, 테이블, API 등)
#### 화면


#### 테이블 명
- map_polygon


#### API endpoint
- `GET` games/by-address?addressDepth1={addressDepth1}&addressDepth2={addressDepth2}

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
