### PR TITLE
[#174] 지도 Polygon 데이터 로컬 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation "com.github.ben-manes.caffeine:caffeine:3.1.8"
     implementation 'org.hibernate:hibernate-spatial:6.3.1.Final'
 
     implementation group: 'org.flywaydb', name: 'flyway-mysql', version: '9.10.2'

--- a/src/main/java/kr/pickple/back/address/service/AddressService.java
+++ b/src/main/java/kr/pickple/back/address/service/AddressService.java
@@ -1,5 +1,13 @@
 package kr.pickple.back.address.service;
 
+import static kr.pickple.back.address.exception.AddressExceptionCode.*;
+
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.pickple.back.address.domain.AddressDepth1;
 import kr.pickple.back.address.domain.AddressDepth2;
 import kr.pickple.back.address.dto.response.AllAddressResponse;
@@ -9,13 +17,6 @@ import kr.pickple.back.address.repository.AddressDepth1Repository;
 import kr.pickple.back.address.repository.AddressDepth2Repository;
 import kr.pickple.back.address.util.AddressParser;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static kr.pickple.back.address.exception.AddressExceptionCode.ADDRESS_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +26,7 @@ public class AddressService {
     private final AddressDepth1Repository addressDepth1Repository;
     private final AddressDepth2Repository addressDepth2Repository;
 
-    @Cacheable(cacheNames = "address", key = "'all'")
+    @Cacheable(cacheManager = "caffeineCacheManager", cacheNames = "address", key = "'all'")
     public AllAddressResponse findAllAddress() {
         final AddressDepth1 addressDepth1 = addressDepth1Repository.findAll()
                 .get(0);

--- a/src/main/java/kr/pickple/back/common/config/CacheConfig.java
+++ b/src/main/java/kr/pickple/back/common/config/CacheConfig.java
@@ -1,10 +1,38 @@
 package kr.pickple.back.common.config;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
+    @Bean
+    public CacheManager caffeineCacheManager() {
+        final List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                .map(cacheType ->
+                        new CaffeineCache(
+                                cacheType.getCacheName(),
+                                Caffeine.newBuilder()
+                                        .recordStats()
+                                        .expireAfterWrite(cacheType.getExpireAfterWrite(), TimeUnit.SECONDS)
+                                        .maximumSize(cacheType.getMaximumSize())
+                                        .build()))
+                .toList();
+
+        final SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caches);
+
+        return cacheManager;
+    }
 }

--- a/src/main/java/kr/pickple/back/common/config/CacheType.java
+++ b/src/main/java/kr/pickple/back/common/config/CacheType.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CacheType {
 
-    POLYGON("polygon", Integer.MAX_VALUE, 1000);
+    POLYGON("polygon", Integer.MAX_VALUE, 1000),
+    ADDRESS("address", Integer.MAX_VALUE, 1000),
+    ;
 
     private final String cacheName;
     private final int expireAfterWrite;

--- a/src/main/java/kr/pickple/back/common/config/CacheType.java
+++ b/src/main/java/kr/pickple/back/common/config/CacheType.java
@@ -1,0 +1,15 @@
+package kr.pickple.back.common.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+
+    POLYGON("polygon", Integer.MAX_VALUE, 1000);
+
+    private final String cacheName;
+    private final int expireAfterWrite;
+    private final int maximumSize;
+}

--- a/src/main/java/kr/pickple/back/game/controller/GameController.java
+++ b/src/main/java/kr/pickple/back/game/controller/GameController.java
@@ -27,6 +27,7 @@ import kr.pickple.back.game.dto.request.MannerScoreReviewsRequest;
 import kr.pickple.back.game.dto.response.GameIdResponse;
 import kr.pickple.back.game.dto.response.GameResponse;
 import kr.pickple.back.game.dto.response.GamesAndLocationResponse;
+import kr.pickple.back.game.service.GameFacadeService;
 import kr.pickple.back.game.service.GameService;
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class GameController {
 
     private final GameService gameService;
+    private final GameFacadeService gameFacadeService;
 
     @PostMapping
     public ResponseEntity<GameIdResponse> createGame(
@@ -144,6 +146,6 @@ public class GameController {
             @RequestParam final String addressDepth2
     ) {
         return ResponseEntity.status(OK)
-                .body(gameService.findGamesWithInAddress(addressDepth1, addressDepth2));
+                .body(gameFacadeService.findGamesWithInAddress(addressDepth1, addressDepth2));
     }
 }

--- a/src/main/java/kr/pickple/back/game/service/GameFacadeService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameFacadeService.java
@@ -1,0 +1,35 @@
+package kr.pickple.back.game.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import kr.pickple.back.address.dto.response.MainAddressResponse;
+import kr.pickple.back.address.service.AddressService;
+import kr.pickple.back.game.dto.response.GameResponse;
+import kr.pickple.back.game.dto.response.GamesAndLocationResponse;
+import kr.pickple.back.map.domain.MapPolygon;
+import kr.pickple.back.map.service.MapService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GameFacadeService {
+
+    private final GameService gameService;
+    private final MapService mapService;
+    private final AddressService addressService;
+
+    public GamesAndLocationResponse findGamesWithInAddress(
+            final String addressDepth1,
+            final String addressDepth2
+    ) {
+        final MainAddressResponse mainAddressResponse = addressService.findMainAddressByNames(addressDepth1,
+                addressDepth2);
+
+        final List<GameResponse> gameResponses = gameService.findGamesWithInAddress(mainAddressResponse);
+        final MapPolygon mapPolygon = mapService.findMapPolygonByMainAddress(mainAddressResponse);
+
+        return GamesAndLocationResponse.of(gameResponses, mapPolygon);
+    }
+}

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -31,12 +31,9 @@ import kr.pickple.back.game.dto.request.GameMemberRegistrationStatusUpdateReques
 import kr.pickple.back.game.dto.request.MannerScoreReview;
 import kr.pickple.back.game.dto.response.GameIdResponse;
 import kr.pickple.back.game.dto.response.GameResponse;
-import kr.pickple.back.game.dto.response.GamesAndLocationResponse;
 import kr.pickple.back.game.exception.GameException;
 import kr.pickple.back.game.repository.GameMemberRepository;
 import kr.pickple.back.game.repository.GameRepository;
-import kr.pickple.back.map.domain.MapPolygon;
-import kr.pickple.back.map.repository.MapPolygonRepository;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.dto.response.MemberResponse;
 import kr.pickple.back.member.exception.MemberException;
@@ -55,7 +52,6 @@ public class GameService {
     private final AddressService addressService;
     private final ChatRoomService chatRoomService;
     private final ChatMessageService chatMessageService;
-    private final MapPolygonRepository mapPolygonRepository;
 
     @Transactional
     public GameIdResponse createGame(final GameCreateRequest gameCreateRequest, final Long loggedInMemberId) {
@@ -296,27 +292,14 @@ public class GameService {
                 .toList();
     }
 
-    public GamesAndLocationResponse findGamesWithInAddress(
-            final String addressDepth1,
-            final String addressDepth2
-    ) {
-        final MainAddressResponse mainAddressResponse = addressService.findMainAddressByNames(addressDepth1,
-                addressDepth2);
-
+    public List<GameResponse> findGamesWithInAddress(final MainAddressResponse mainAddressResponse) {
         final List<Game> games = gameRepository.findGamesWithInAddress(
                 mainAddressResponse.getAddressDepth1(),
                 mainAddressResponse.getAddressDepth2()
         );
 
-        final MapPolygon polygon = mapPolygonRepository.findByAddressDepth1AndAddressDepth2(
-                mainAddressResponse.getAddressDepth1(),
-                mainAddressResponse.getAddressDepth2()
-        );
-
-        final List<GameResponse> gameResponses = games.stream()
+        return games.stream()
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
                 .toList();
-
-        return GamesAndLocationResponse.of(gameResponses, polygon);
     }
 }

--- a/src/main/java/kr/pickple/back/map/service/MapService.java
+++ b/src/main/java/kr/pickple/back/map/service/MapService.java
@@ -1,0 +1,26 @@
+package kr.pickple.back.map.service;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.pickple.back.address.dto.response.MainAddressResponse;
+import kr.pickple.back.map.domain.MapPolygon;
+import kr.pickple.back.map.repository.MapPolygonRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MapService {
+
+    private final MapPolygonRepository mapPolygonRepository;
+
+    @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "polygon", cacheManager = "caffeineCacheManager", key = "#mainAddressResponse.addressDepth2.name")
+    public MapPolygon findMapPolygonByMainAddress(final MainAddressResponse mainAddressResponse) {
+        return mapPolygonRepository.findByAddressDepth1AndAddressDepth2(
+                mainAddressResponse.getAddressDepth1(),
+                mainAddressResponse.getAddressDepth2()
+        );
+    }
+}

--- a/src/main/java/kr/pickple/back/map/service/MapService.java
+++ b/src/main/java/kr/pickple/back/map/service/MapService.java
@@ -16,7 +16,7 @@ public class MapService {
     private final MapPolygonRepository mapPolygonRepository;
 
     @Transactional(readOnly = true)
-    @Cacheable(cacheNames = "polygon", cacheManager = "caffeineCacheManager", key = "#mainAddressResponse.addressDepth2.name")
+    @Cacheable(cacheManager = "caffeineCacheManager", cacheNames = "polygon", key = "#mainAddressResponse.addressDepth2.name")
     public MapPolygon findMapPolygonByMainAddress(final MainAddressResponse mainAddressResponse) {
         return mapPolygonRepository.findByAddressDepth1AndAddressDepth2(
                 mainAddressResponse.getAddressDepth1(),


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 서울시의 각 구별로 저장된 polygon 데이터를 로컬 캐시로 적용하여 많은 데이터를 빠르게 저장한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] build.gradle에 Cache 의존성 추가
- [X] CacheConfig에 CaffeineCache 설정 추가 
- [X] 기존 코드 리팩토링 및 캐싱 적용
---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---
#### 테이블 명
- map_polygon


#### API endpoint
- `GET` /games/by-address?addressDepth1=서울시&addressDepth2=영등포구

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
