### PR TITLE
[#182] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/kr/pickple/back/auth/controller/OauthController.java
+++ b/src/main/java/kr/pickple/back/auth/controller/OauthController.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletResponse;
 import kr.pickple.back.auth.config.property.JwtProperties;
+import kr.pickple.back.auth.config.resolver.Login;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
 import kr.pickple.back.auth.dto.response.AccessTokenResponse;
 import kr.pickple.back.auth.service.OauthService;
@@ -78,5 +80,16 @@ public class OauthController {
 
         return ResponseEntity.status(CREATED)
                 .body(regeneratedAccessToken);
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @Login final Long loggedInMemberId,
+            @CookieValue("refresh-token") final String refreshToken
+    ) {
+        oauthService.deleteRefreshToken(refreshToken);
+
+        return ResponseEntity.status(NO_CONTENT)
+                .build();
     }
 }

--- a/src/main/java/kr/pickple/back/auth/domain/token/JwtProvider.java
+++ b/src/main/java/kr/pickple/back/auth/domain/token/JwtProvider.java
@@ -76,11 +76,6 @@ public class JwtProvider {
                 .parseSignedClaims(token);
     }
 
-    public void validateTokens(final AuthTokens authTokens) {
-        validateAccessToken(authTokens.getAccessToken());
-        validateRefreshToken(authTokens.getRefreshToken());
-    }
-
     public void validateAccessToken(final String accessToken) {
         try {
             parseToken(accessToken);

--- a/src/main/java/kr/pickple/back/auth/service/OauthService.java
+++ b/src/main/java/kr/pickple/back/auth/service/OauthService.java
@@ -88,4 +88,8 @@ public class OauthService {
 
         throw new AuthException(AUTH_FAIL_TO_VALIDATE_TOKEN);
     }
+
+    public void deleteRefreshToken(final String refreshToken) {
+        refreshTokenRepository.deleteById(refreshToken);
+    }
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 로그아웃시 RefreshToken 테이블에서 로그인 내역을 삭제한다.
  - 로그아웃은 로그인이 되었을 때 사용자가 직접 로그아웃을 요청하는 경우에만 테이블에서 삭제처리한다.
  - RefreshToken 만료로 인하여 자동 로그아웃이 될 때는 동작하지 않는 API임
     - 이 부분은 추후 Redis의 TTL을 설정하여 만료되면 자동으로 사라지게끔 설정

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] RefreshToken에서 테이블 삭제
- [X] Auth 불 필요한 로직 제거

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 사용자가 클라이언트 단에서 직접 로그아웃 버튼 클릭시 API를 쏴서 RefreshToken을 삭제할 수 있지만 RefreshToken이 만료가 되었을 때 처리 로직에 대한 고민이 있습니다. 만약 사용자가 RefreshToken이 만료되었을 경우 Controller에서 인증된 사용자인지 확인하게되는데 만료로 인해 logout에 API를 이용하지 못하게되고 이렇게 되면 테이블에 평생 지워지지 않는 RefreshToken이 생기게됩니다.
- 이와 관련하여 대처 방법으로 주기적으로 배치를 이용해서 시간을 계산해보고 만료된 토큰은 삭제처리해주는 작업, 아니면 Redis를 이용하여 토큰 만료시간과 동일하게 설정하여 자동으로 삭제시키는 방법이 있을 수 있을 것 같습니다.

---

#### 테이블 명
- refresh_token


#### API endpoint
- /auth/logout

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
