### PR TITLE
[#187] 채팅방 나가기 이후, 채팅방 목록 조회 시 사라지지 않는 현상 해결

### DIFF
--- a/src/main/java/kr/pickple/back/chat/controller/ChatRoomController.java
+++ b/src/main/java/kr/pickple/back/chat/controller/ChatRoomController.java
@@ -50,12 +50,12 @@ public class ChatRoomController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ChatRoomResponse>> findAllChatRoomsByType(
+    public ResponseEntity<List<ChatRoomResponse>> findAllActiveChatRoomsByType(
             @Login final Long loggedInMemberId,
             @RequestParam final RoomType type
     ) {
         return ResponseEntity.status(OK)
-                .body(chatRoomFindService.findAllChatRoomsByType(loggedInMemberId, type));
+                .body(chatRoomFindService.findAllActiveChatRoomsByType(loggedInMemberId, type));
     }
 
     @GetMapping("/{roomId}")

--- a/src/main/java/kr/pickple/back/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/kr/pickple/back/chat/repository/ChatRoomMemberRepository.java
@@ -13,4 +13,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     Boolean existsByActiveTrueAndChatRoomAndMember(final ChatRoom chatRoom, final Member member);
 
     List<ChatRoomMember> findAllByMember(final Member member);
+
+    List<ChatRoomMember> findAllByActiveTrueAndMember(final Member member);
 }

--- a/src/main/java/kr/pickple/back/chat/service/ChatRoomFindService.java
+++ b/src/main/java/kr/pickple/back/chat/service/ChatRoomFindService.java
@@ -38,10 +38,10 @@ public class ChatRoomFindService {
     private final CrewRepository crewRepository;
     private final GameRepository gameRepository;
 
-    public List<ChatRoomResponse> findAllChatRoomsByType(final Long loggedInMemberId, final RoomType type) {
+    public List<ChatRoomResponse> findAllActiveChatRoomsByType(final Long loggedInMemberId, final RoomType type) {
         final Member loggedInMember = findMemberById(loggedInMemberId);
 
-        return chatRoomMemberRepository.findAllByMember(loggedInMember)
+        return chatRoomMemberRepository.findAllByActiveTrueAndMember(loggedInMember)
                 .stream()
                 .map(ChatRoomMember::getChatRoom)
                 .filter(chatRoom -> chatRoom.isMatchedRoomType(type))


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 개인 채팅방을 나가도, 채팅방 목록 조회 시 사라지지 않는 버그를 해결한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 나간 채팅방 목록에서 지우기

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
