### PR TITLE
[#194] 크루 생성 개수 초과 예외 적용

### DIFF
--- a/src/main/java/kr/pickple/back/crew/exception/CrewExceptionCode.java
+++ b/src/main/java/kr/pickple/back/crew/exception/CrewExceptionCode.java
@@ -1,9 +1,10 @@
 package kr.pickple.back.crew.exception;
 
+import org.springframework.http.HttpStatus;
+
 import kr.pickple.back.common.exception.ExceptionCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public enum CrewExceptionCode implements ExceptionCode {
     CREW_MEMBER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "CRE-009", "해당 사용자는 크루 가입 신청을 거절하거나 취소할 권한 없음"),
     CREW_MEMBER_STATUS_IS_NOT_WAITING(HttpStatus.BAD_REQUEST, "CRE-010", "해당 크루에 가입 신청 대기 상태가 아니라면, 가입 신청을 취소할 수 없음"),
     CREW_LEADER_CANNOT_BE_DELETED(HttpStatus.BAD_REQUEST, "CRE-011", "크루장은 자신의 크루에서 삭제될 수 없음"),
+    CREW_CREATE_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "CRE-012", "사용자는 크루를 특정 MAX 값을 초과하여 생성할 수 없음"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -35,6 +35,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CrewService {
 
+    private static final Integer CREW_CREATE_MAX_SIZE = 3;
+
     private final S3Properties s3Properties;
     private final CrewRepository crewRepository;
     private final MemberRepository memberRepository;
@@ -47,6 +49,8 @@ public class CrewService {
 
         final Member leader = memberRepository.findById(loggedInMemberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        validateMemberCreatedCrewsCount(leader);
 
         final MainAddressResponse mainAddressResponse = addressService.findMainAddressByNames(
                 crewCreateRequest.getAddressDepth1(),
@@ -67,6 +71,14 @@ public class CrewService {
         final Long crewId = crewRepository.save(crew).getId();
 
         return CrewIdResponse.from(crewId);
+    }
+
+    private void validateMemberCreatedCrewsCount(final Member leader) {
+        final Long createdCrewsCount = leader.getCreatedCrewsCount();
+
+        if (createdCrewsCount >= CREW_CREATE_MAX_SIZE) {
+            throw new CrewException(CREW_CREATE_MAX_COUNT_EXCEEDED, createdCrewsCount);
+        }
     }
 
     public CrewProfileResponse findCrewById(final Long crewId) {

--- a/src/main/java/kr/pickple/back/member/domain/Member.java
+++ b/src/main/java/kr/pickple/back/member/domain/Member.java
@@ -134,6 +134,10 @@ public class Member extends BaseEntity {
         return memberCrews.getCreatedCrewsByMember(this);
     }
 
+    public Long getCreatedCrewsCount() {
+        return memberCrews.getCreatedCrewsCountByMember(this);
+    }
+
     public List<Game> getGamesByStatus(final RegistrationStatus status) {
         return memberGames.getGamesByStatus(status);
     }

--- a/src/main/java/kr/pickple/back/member/domain/MemberCrews.java
+++ b/src/main/java/kr/pickple/back/member/domain/MemberCrews.java
@@ -33,4 +33,11 @@ public class MemberCrews {
     public void addMemberCrew(final CrewMember memberCrew) {
         memberCrews.add(memberCrew);
     }
+
+    public Long getCreatedCrewsCountByMember(final Member member) {
+        return memberCrews.stream()
+                .map(CrewMember::getCrew)
+                .filter(crew -> crew.isLeader(member))
+                .count();
+    }
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 크루 정책상 사용자는 크루를 3개 이상 생성할 수 없음.
  - 관련된 내용 예외 처리

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] 크루 생성시 사용자가 생성한 크루의 개수를 조회하여 예외 처리

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---

#### 테이블 명
- crew


#### API endpoint
- `POST` /crews

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
