### PR TITLE
[#201] 자기소개, 상세설명 기본값 추가 및 nullable로 변경

### DIFF
--- a/src/main/java/kr/pickple/back/crew/domain/Crew.java
+++ b/src/main/java/kr/pickple/back/crew/domain/Crew.java
@@ -3,6 +3,7 @@ package kr.pickple.back.crew.domain;
 import static kr.pickple.back.crew.domain.CrewStatus.*;
 import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 import jakarta.persistence.Column;
@@ -45,7 +46,7 @@ public class Crew extends BaseEntity {
     private String name;
 
     @Column(length = 1000)
-    private String content;
+    private String content = MessageFormat.format("안녕하세요. {0}입니다.", name);
 
     @NotNull
     private Integer memberCount = 1;

--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -44,9 +44,8 @@ public class Game extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
     @Column(length = 1000)
-    private String content;
+    private String content = "즐거운 농구 경기해요!";
 
     @NotNull
     private LocalDate playDate;

--- a/src/main/java/kr/pickple/back/member/domain/Member.java
+++ b/src/main/java/kr/pickple/back/member/domain/Member.java
@@ -2,6 +2,7 @@ package kr.pickple.back.member.domain;
 
 import static kr.pickple.back.member.exception.MemberExceptionCode.*;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 import jakarta.persistence.Column;
@@ -55,7 +56,7 @@ public class Member extends BaseEntity {
     private String nickname;
 
     @Column(length = 1000)
-    private String introduction;
+    private String introduction = MessageFormat.format("안녕하세요. {0}입니다.", nickname);
 
     @NotNull
     @Column(length = 300)


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 회원 생성 시 자기소개의 기본값을 추가한다.
- 크루 상세설명 기본값을 추가한다.
- 게스트 모집 상세설명을 null이 가능하도록 변경한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 회원 자기소개 기본값 추가
- [x] 크루 상세설명 기본값 추가
- [x] 게스트 모집 상세설명 null로 변경

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
