### PR TITLE
[#204] 특정 사용자와의 1:1 채팅방 조회 API의 응답값 변경

### DIFF
--- a/src/main/http/chat/chat.http
+++ b/src/main/http/chat/chat.http
@@ -8,7 +8,7 @@ Content-Type: application/json
 }
 
 ### 특정 사용자와의 1:1 채팅방 존재 여부 조회
-GET http://localhost:8080/rooms/personal/existed?receiver=2
+GET http://localhost:8080/rooms/personal?receiver=1
 Authorization:
 
 ### 참여중인 모든 채팅방 목록 조회(개인)

--- a/src/main/java/kr/pickple/back/chat/controller/ChatRoomController.java
+++ b/src/main/java/kr/pickple/back/chat/controller/ChatRoomController.java
@@ -40,13 +40,13 @@ public class ChatRoomController {
                 .body(chatRoomService.createPersonalRoom(senderId, personalChatRoomCreateRequest));
     }
 
-    @GetMapping("/personal/existed")
-    public ResponseEntity<PersonalChatRoomExistedResponse> getActivePersonalChatRoomWithReceiver(
+    @GetMapping("/personal")
+    public ResponseEntity<PersonalChatRoomExistedResponse> findActivePersonalChatRoomWithReceiver(
             @Login final Long senderId,
             @RequestParam("receiver") final Long receiverId
     ) {
         return ResponseEntity.status(OK)
-                .body(chatRoomService.getActivePersonalChatRoomWithReceiver(senderId, receiverId));
+                .body(chatRoomService.findActivePersonalChatRoomWithReceiver(senderId, receiverId));
     }
 
     @GetMapping

--- a/src/main/java/kr/pickple/back/chat/dto/response/PersonalChatRoomExistedResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/PersonalChatRoomExistedResponse.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor(staticName = "of")
 public class PersonalChatRoomExistedResponse {
 
-    private Boolean isRoomExisted;
+    private Long roomId;
     private Boolean isSenderActive;
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 특정 사용자와의 1:1 채팅방 조회 API의 응답값을 변경한다.
- 1:1 채팅방 조회 시, sender가 active하지 않은 경우 roomId를 알 수 없기 때문
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 기존 boolean 응답을 roomId로 응답하기

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
