### PR TITLE
[#207] 통합테스트 속도 개선

### DIFF
--- a/src/test/java/kr/pickple/back/auth/IntegrationAuthTest.java
+++ b/src/test/java/kr/pickple/back/auth/IntegrationAuthTest.java
@@ -1,0 +1,26 @@
+package kr.pickple.back.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import kr.pickple.back.auth.domain.token.JwtProvider;
+import kr.pickple.back.auth.service.OauthService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+public abstract class IntegrationAuthTest {
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockBean
+    protected OauthService oauthService;
+}

--- a/src/test/java/kr/pickple/back/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/pickple/back/auth/controller/AuthControllerTest.java
@@ -8,39 +8,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import jakarta.servlet.http.Cookie;
+import kr.pickple.back.auth.IntegrationAuthTest;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
 import kr.pickple.back.auth.domain.token.AuthTokens;
-import kr.pickple.back.auth.domain.token.JwtProvider;
 import kr.pickple.back.auth.dto.response.AccessTokenResponse;
-import kr.pickple.back.auth.service.OauthService;
 import kr.pickple.back.fixture.dto.MemberDtoFixtures;
 import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-class AuthControllerTest {
+class AuthControllerTest extends IntegrationAuthTest {
 
     private static final String BASE_URL = "/auth";
     private static final String OAUTH_PROVIDER = "kakao";
     private static final String AUTH_CODE = "authCode";
-
-    @MockBean
-    private OauthService oauthService;
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private JwtProvider jwtProvider;
 
     @Test
     @DisplayName("oauth 제공자를 받으면 로그인 페이지로 리다이렉트 시킬 수 있다.")

--- a/src/test/java/kr/pickple/back/auth/docs/AuthDocumentTest.java
+++ b/src/test/java/kr/pickple/back/auth/docs/AuthDocumentTest.java
@@ -13,44 +13,25 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 
 import jakarta.servlet.http.Cookie;
+import kr.pickple.back.auth.IntegrationAuthTest;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
 import kr.pickple.back.auth.domain.token.AuthTokens;
-import kr.pickple.back.auth.domain.token.JwtProvider;
 import kr.pickple.back.auth.dto.response.AccessTokenResponse;
-import kr.pickple.back.auth.service.OauthService;
 import kr.pickple.back.fixture.dto.MemberDtoFixtures;
 import kr.pickple.back.member.dto.response.AuthenticatedMemberResponse;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-class AuthDocumentTest {
+class AuthDocumentTest extends IntegrationAuthTest {
 
     private static final String BASE_URL = "/auth";
     private static final String OAUTH_PROVIDER = "kakao";
     private static final String AUTH_CODE = "authCode";
-
-    @MockBean
-    private OauthService oauthService;
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private JwtProvider jwtProvider;
 
     @Test
     @DisplayName("oauth 제공자를 받으면 로그인 페이지로 리다이렉트 시킬 수 있다.")

--- a/src/test/java/kr/pickple/back/auth/domain/JwtProviderTest.java
+++ b/src/test/java/kr/pickple/back/auth/domain/JwtProviderTest.java
@@ -4,20 +4,14 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
+import kr.pickple.back.auth.IntegrationAuthTest;
 import kr.pickple.back.auth.domain.oauth.OauthProvider;
 import kr.pickple.back.auth.domain.token.AuthTokens;
-import kr.pickple.back.auth.domain.token.JwtProvider;
 
-@SpringBootTest
-class JwtProviderTest {
+class JwtProviderTest extends IntegrationAuthTest {
 
     private static final Long MEMBER_ID = 1L;
-
-    @Autowired
-    private JwtProvider jwtProvider;
 
     @Test
     @DisplayName("memberId로 accessToken과 refreshToken을 만들 수 있다.")

--- a/src/test/java/kr/pickple/back/game/IntegrationGameTest.java
+++ b/src/test/java/kr/pickple/back/game/IntegrationGameTest.java
@@ -1,0 +1,34 @@
+package kr.pickple.back.game;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.pickple.back.auth.domain.token.JwtProvider;
+import kr.pickple.back.fixture.setup.GameSetup;
+import kr.pickple.back.fixture.setup.MemberSetup;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+public abstract class IntegrationGameTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    @Autowired
+    protected GameSetup gameSetup;
+
+    @Autowired
+    protected MemberSetup memberSetup;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+}

--- a/src/test/java/kr/pickple/back/game/controller/GameControllerTest.java
+++ b/src/test/java/kr/pickple/back/game/controller/GameControllerTest.java
@@ -10,21 +10,13 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import kr.pickple.back.auth.domain.token.AuthTokens;
-import kr.pickple.back.auth.domain.token.JwtProvider;
 import kr.pickple.back.fixture.dto.GameDtoFixtures;
-import kr.pickple.back.fixture.setup.GameSetup;
-import kr.pickple.back.fixture.setup.MemberSetup;
+import kr.pickple.back.game.IntegrationGameTest;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.game.domain.GameMember;
 import kr.pickple.back.game.dto.request.GameMemberRegistrationStatusUpdateRequest;
@@ -32,26 +24,9 @@ import kr.pickple.back.game.dto.request.MannerScoreReviewsRequest;
 import kr.pickple.back.member.domain.Member;
 
 @Transactional
-@SpringBootTest
-@AutoConfigureMockMvc
-class GameControllerTest {
+class GameControllerTest extends IntegrationGameTest {
 
     private static final String BASE_URL = "/games";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private JwtProvider jwtProvider;
-
-    @Autowired
-    private GameSetup gameSetup;
-
-    @Autowired
-    private MemberSetup memberSetup;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("사용자는 게스트 모집글의 상세 정보를 조회할 수 있다.")

--- a/src/test/java/kr/pickple/back/game/docs/GameDocumentTest.java
+++ b/src/test/java/kr/pickple/back/game/docs/GameDocumentTest.java
@@ -14,25 +14,17 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.pickple.back.auth.domain.token.AuthTokens;
-import kr.pickple.back.auth.domain.token.JwtProvider;
 import kr.pickple.back.fixture.dto.GameDtoFixtures;
-import kr.pickple.back.fixture.setup.GameSetup;
-import kr.pickple.back.fixture.setup.MemberSetup;
+import kr.pickple.back.game.IntegrationGameTest;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.game.domain.GameMember;
 import kr.pickple.back.game.dto.request.GameMemberRegistrationStatusUpdateRequest;
@@ -40,27 +32,9 @@ import kr.pickple.back.game.dto.request.MannerScoreReviewsRequest;
 import kr.pickple.back.member.domain.Member;
 
 @Transactional
-@SpringBootTest
-@AutoConfigureRestDocs
-@AutoConfigureMockMvc
-class GameDocumentTest {
+class GameDocumentTest extends IntegrationGameTest {
 
     private static final String BASE_URL = "/games";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private JwtProvider jwtProvider;
-
-    @Autowired
-    private MemberSetup memberSetup;
-
-    @Autowired
-    private GameSetup gameSetup;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("게스트 모집글 상세 조회")

--- a/src/test/java/kr/pickple/back/member/IntegrationMemberTest.java
+++ b/src/test/java/kr/pickple/back/member/IntegrationMemberTest.java
@@ -1,0 +1,34 @@
+package kr.pickple.back.member;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.pickple.back.auth.domain.token.JwtProvider;
+import kr.pickple.back.fixture.setup.CrewSetup;
+import kr.pickple.back.fixture.setup.MemberSetup;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+public abstract class IntegrationMemberTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected MemberSetup memberSetup;
+
+    @Autowired
+    protected CrewSetup crewSetup;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+}

--- a/src/test/java/kr/pickple/back/member/controller/MemberControllerTest.java
+++ b/src/test/java/kr/pickple/back/member/controller/MemberControllerTest.java
@@ -6,46 +6,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import kr.pickple.back.auth.domain.token.AuthTokens;
-import kr.pickple.back.auth.domain.token.JwtProvider;
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.fixture.dto.MemberDtoFixtures;
-import kr.pickple.back.fixture.setup.CrewSetup;
-import kr.pickple.back.fixture.setup.MemberSetup;
+import kr.pickple.back.member.IntegrationMemberTest;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.dto.request.MemberCreateRequest;
 
 @Transactional
-@SpringBootTest
-@AutoConfigureMockMvc
-class MemberControllerTest {
+class MemberControllerTest extends IntegrationMemberTest {
 
     private static final String BASE_URL = "/members";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private MemberSetup memberSetup;
-
-    @Autowired
-    private CrewSetup crewSetup;
-
-    @Autowired
-    private JwtProvider jwtProvider;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("회원을 생성할 수 있다.")

--- a/src/test/java/kr/pickple/back/member/docs/MemberDocumentTest.java
+++ b/src/test/java/kr/pickple/back/member/docs/MemberDocumentTest.java
@@ -11,48 +11,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.pickple.back.auth.domain.token.AuthTokens;
-import kr.pickple.back.auth.domain.token.JwtProvider;
 import kr.pickple.back.fixture.dto.MemberDtoFixtures;
-import kr.pickple.back.fixture.setup.CrewSetup;
-import kr.pickple.back.fixture.setup.MemberSetup;
+import kr.pickple.back.member.IntegrationMemberTest;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.dto.request.MemberCreateRequest;
 
 @Transactional
-@SpringBootTest
-@AutoConfigureRestDocs
-@AutoConfigureMockMvc
-class MemberDocumentTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private MemberSetup memberSetup;
-
-    @Autowired
-    private CrewSetup crewSetup;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private JwtProvider jwtProvider;
+class MemberDocumentTest extends IntegrationMemberTest {
 
     @Test
     @DisplayName("회원을 생성할 수 있다.")


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- SpringBootTest 통합테스트가 여러 번 실행되는 것을 도메인 별 1회로 줄여 테스트 속도를 개선한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] Game 도메인 Integration 추상 클래스 생성 및 적용
- [X] Auth 도메인 Integration 추상 클래스 생성 및 적용
- [X] Member 도메인 Integration 추상 클래스 생성 및 적용

**적용 전**
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/4012534b-34ba-4d6b-ad2d-3fc72037cc47)

**적용 후**
![image](https://github.com/Java-and-Script/pickple-back/assets/92444744/498a1b74-01fc-4be7-9068-18238ea9889d)

**테스트 시간**: `8초` -> `5초`로 성능 개선
**통합테스트 횟수**:  `7번` -> `3번`으로 감소

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---


### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
