### PR TITLE
[#196] 크루 알람, 게임 알람 최신 순 조회, 커서 기반 페이징 

### DIFF
--- a/src/main/http/alram/alarm.http
+++ b/src/main/http/alram/alarm.http
@@ -8,6 +8,11 @@ GET http://localhost:8080/alarms/unread
 Authorization:
 Content-Type: application/json
 
+### 해당 사용자의 모든 알람 목록 조회
+GET http://localhost:8080/alarms?size=6
+Authorization:
+Content-Type: application/json
+
 ### 해당 사용자의 모든 알람 삭제
 DELETE http://localhost:8080/alarms
 Authorization:

--- a/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
+++ b/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
@@ -1,19 +1,16 @@
 package kr.pickple.back.alarm.controller;
 
 import kr.pickple.back.alarm.dto.response.AlarmExistStatusResponse;
+import kr.pickple.back.alarm.dto.response.AlarmResponse;
 import kr.pickple.back.alarm.service.AlarmService;
 import kr.pickple.back.alarm.service.SseEmitterService;
+import kr.pickple.back.alarm.util.CursorResult;
 import kr.pickple.back.auth.config.resolver.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.util.Map;
 
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
@@ -50,11 +47,13 @@ public class AlarmController {
     }
 
     @GetMapping
-    public ResponseEntity<Map<String, Object>> findAllAlarms(
-            @Login final Long loggedInMemberId
+    public ResponseEntity<CursorResult<AlarmResponse>> findAllAlarms(
+            @Login final Long loggedInMemberId,
+            @RequestParam(value = "cursorId", required = false) Long cursorId,
+            @RequestParam(value = "size", defaultValue = "6") int size
     ) {
-        return ResponseEntity.status(OK)
-                .body(alarmService.findAllAlarms(loggedInMemberId));
+        final CursorResult<AlarmResponse> result = alarmService.findAllAlarms(loggedInMemberId, cursorId, size);
+        return ResponseEntity.ok(result);
     }
 
     @DeleteMapping

--- a/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
+++ b/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.Map;
+
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -45,6 +47,14 @@ public class AlarmController {
         return ResponseEntity
                 .status(OK)
                 .body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> findAllAlarms(
+            @Login final Long loggedInMemberId
+    ) {
+        return ResponseEntity.status(OK)
+                .body(alarmService.findAllAlarms(loggedInMemberId));
     }
 
     @DeleteMapping

--- a/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
+++ b/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
@@ -49,12 +49,11 @@ public class AlarmController {
     @GetMapping
     public ResponseEntity<CursorResult<AlarmResponse>> findAllAlarms(
             @Login final Long loggedInMemberId,
-            @RequestParam(value = "lastCrewAlarmId", required = false) Long lastCrewAlarmId,
-            @RequestParam(value = "lastGameAlarmId", required = false) Long lastGameAlarmId,
+            @RequestParam(value = "cursorId", required = false) Long cursorId,
             @RequestParam(value = "size", defaultValue = "6") int size
     ) {
         final CursorResult<AlarmResponse> result = alarmService.findAllAlarms(
-                loggedInMemberId, lastCrewAlarmId, lastGameAlarmId, size);
+                loggedInMemberId, cursorId, size);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
+++ b/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
@@ -49,10 +49,12 @@ public class AlarmController {
     @GetMapping
     public ResponseEntity<CursorResult<AlarmResponse>> findAllAlarms(
             @Login final Long loggedInMemberId,
-            @RequestParam(value = "cursorId", required = false) Long cursorId,
+            @RequestParam(value = "lastCrewAlarmId", required = false) Long lastCrewAlarmId,
+            @RequestParam(value = "lastGameAlarmId", required = false) Long lastGameAlarmId,
             @RequestParam(value = "size", defaultValue = "6") int size
     ) {
-        final CursorResult<AlarmResponse> result = alarmService.findAllAlarms(loggedInMemberId, cursorId, size);
+        final CursorResult<AlarmResponse> result = alarmService.findAllAlarms(
+                loggedInMemberId, lastCrewAlarmId, lastGameAlarmId, size);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
@@ -4,6 +4,4 @@ import java.time.LocalDateTime;
 
 public interface AlarmResponse {
     LocalDateTime getCreatedAt();
-
-    Long getId();
 }

--- a/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
@@ -4,4 +4,5 @@ import java.time.LocalDateTime;
 
 public interface AlarmResponse {
     LocalDateTime getCreatedAt();
+    Long getAlarmId();
 }

--- a/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
@@ -1,0 +1,9 @@
+package kr.pickple.back.alarm.dto.response;
+
+import java.time.LocalDateTime;
+
+public interface AlarmResponse {
+    LocalDateTime getCreatedAt();
+
+    Long getId();
+}

--- a/src/main/java/kr/pickple/back/alarm/dto/response/CrewAlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/CrewAlarmResponse.java
@@ -43,9 +43,4 @@ public class CrewAlarmResponse implements AlarmResponse{
     public LocalDateTime getCreatedAt() {
         return this.createdAt;
     }
-
-    @Override
-    public Long getId() {
-        return this.crewAlarmId;
-    }
 }

--- a/src/main/java/kr/pickple/back/alarm/dto/response/CrewAlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/CrewAlarmResponse.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 @JsonSerialize
 @RequiredArgsConstructor
-public class CrewAlarmResponse {
+public class CrewAlarmResponse implements AlarmResponse{
 
     private final Long crewAlarmId;
     private final Long crewId;
@@ -37,5 +37,15 @@ public class CrewAlarmResponse {
                 .isRead(crewAlarm.getIsRead())
                 .crewAlarmMessage(crewAlarm.getCrewAlarmType())
                 .build();
+    }
+
+    @Override
+    public LocalDateTime getCreatedAt() {
+        return this.createdAt;
+    }
+
+    @Override
+    public Long getId() {
+        return this.crewAlarmId;
     }
 }

--- a/src/main/java/kr/pickple/back/alarm/dto/response/CrewAlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/CrewAlarmResponse.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 @JsonSerialize
 @RequiredArgsConstructor
-public class CrewAlarmResponse implements AlarmResponse{
+public class CrewAlarmResponse implements AlarmResponse {
 
     private final Long crewAlarmId;
     private final Long crewId;
@@ -42,5 +42,10 @@ public class CrewAlarmResponse implements AlarmResponse{
     @Override
     public LocalDateTime getCreatedAt() {
         return this.createdAt;
+    }
+
+    @Override
+    public Long getAlarmId() {
+        return crewAlarmId;
     }
 }

--- a/src/main/java/kr/pickple/back/alarm/dto/response/GameAlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/GameAlarmResponse.java
@@ -17,7 +17,7 @@ import java.time.LocalTime;
 @Builder
 @JsonSerialize
 @RequiredArgsConstructor
-public class GameAlarmResponse implements AlarmResponse{
+public class GameAlarmResponse implements AlarmResponse {
 
     private final Long gameAlarmId;
     private final Long gameId;
@@ -48,5 +48,10 @@ public class GameAlarmResponse implements AlarmResponse{
     @Override
     public LocalDateTime getCreatedAt() {
         return this.createdAt;
+    }
+
+    @Override
+    public Long getAlarmId() {
+        return gameAlarmId;
     }
 }

--- a/src/main/java/kr/pickple/back/alarm/dto/response/GameAlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/GameAlarmResponse.java
@@ -49,9 +49,4 @@ public class GameAlarmResponse implements AlarmResponse{
     public LocalDateTime getCreatedAt() {
         return this.createdAt;
     }
-
-    @Override
-    public Long getId() {
-        return this.gameAlarmId;
-    }
 }

--- a/src/main/java/kr/pickple/back/alarm/dto/response/GameAlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/GameAlarmResponse.java
@@ -17,9 +17,9 @@ import java.time.LocalTime;
 @Builder
 @JsonSerialize
 @RequiredArgsConstructor
-public class GameAlarmResponse {
+public class GameAlarmResponse implements AlarmResponse{
 
-    private final Long GameAlarmId;
+    private final Long gameAlarmId;
     private final Long gameId;
     private final String mainAddress;
     private final LocalDateTime createdAt;
@@ -33,7 +33,7 @@ public class GameAlarmResponse {
         final Game game = gameAlarm.getGame();
 
         return GameAlarmResponse.builder()
-                .GameAlarmId(gameAlarm.getId())
+                .gameAlarmId(gameAlarm.getId())
                 .gameId(game.getId())
                 .mainAddress(gameAlarm.getGame().getMainAddress())
                 .createdAt(gameAlarm.getCreatedAt())
@@ -43,5 +43,15 @@ public class GameAlarmResponse {
                 .isRead(gameAlarm.getIsRead())
                 .gameAlarmMessage(gameAlarm.getGameAlarmType())
                 .build();
+    }
+
+    @Override
+    public LocalDateTime getCreatedAt() {
+        return this.createdAt;
+    }
+
+    @Override
+    public Long getId() {
+        return this.gameAlarmId;
     }
 }

--- a/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
@@ -22,14 +22,18 @@ public interface CrewAlarmRepository extends JpaRepository<CrewAlarm, Long> {
             "FROM CrewAlarm ca LEFT JOIN FETCH ca.crew " +
             "WHERE ca.member.id = :memberId AND ca.id < :cursorId " +
             "ORDER BY ca.createdAt DESC")
-    List<CrewAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
-                                                                    @Param("cursorId") final Long cursorId,
-                                                                    final PageRequest of);
+    List<CrewAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
+            @Param("memberId") final Long loggedInMemberId,
+            @Param("cursorId") final Long cursorId,
+            final PageRequest of
+    );
 
     @Query("SELECT ca " +
             "FROM CrewAlarm ca LEFT JOIN FETCH ca.crew " +
             "WHERE ca.member.id = :memberId " +
             "ORDER BY ca.createdAt DESC")
-    List<CrewAlarm> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
-                                                       final PageRequest of);
+    List<CrewAlarm> findByMemberIdOrderByCreatedAtDesc(
+            @Param("memberId") final Long loggedInMemberId,
+            final PageRequest of
+    );
 }

--- a/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
@@ -4,11 +4,14 @@ import kr.pickple.back.alarm.domain.AlarmStatus;
 import kr.pickple.back.alarm.domain.CrewAlarm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CrewAlarmRepository extends JpaRepository<CrewAlarm, Long> {
 
     boolean existsByMemberIdAndIsRead(final Long memberId, final AlarmStatus alarmStatus);
+
+    List<CrewAlarm> findByMemberId(final Long memberId);
 
     void deleteByMemberId(final Long memberId);
 

--- a/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
@@ -2,8 +2,10 @@ package kr.pickple.back.alarm.repository;
 
 import kr.pickple.back.alarm.domain.AlarmStatus;
 import kr.pickple.back.alarm.domain.CrewAlarm;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,10 +14,22 @@ public interface CrewAlarmRepository extends JpaRepository<CrewAlarm, Long> {
 
     boolean existsByMemberIdAndIsRead(final Long memberId, final AlarmStatus alarmStatus);
 
-    @Query("SELECT ca FROM CrewAlarm ca JOIN FETCH ca.crew WHERE ca.member.id = :memberId")
-    List<CrewAlarm> findByMemberId(final Long memberId);
-
     void deleteByMemberId(final Long memberId);
 
     Optional<CrewAlarm> findByMemberIdAndId(final Long memberId, final Long crewAlarmId);
+
+    @Query("SELECT ca " +
+            "FROM CrewAlarm ca LEFT JOIN FETCH ca.crew " +
+            "WHERE ca.member.id = :memberId AND ca.id < :cursorId " +
+            "ORDER BY ca.createdAt DESC")
+    List<CrewAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
+                                                                    @Param("cursorId") final Long cursorId,
+                                                                    final PageRequest of);
+
+    @Query("SELECT ca " +
+            "FROM CrewAlarm ca LEFT JOIN FETCH ca.crew " +
+            "WHERE ca.member.id = :memberId " +
+            "ORDER BY ca.createdAt DESC")
+    List<CrewAlarm> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
+                                                       final PageRequest of);
 }

--- a/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
@@ -3,6 +3,7 @@ package kr.pickple.back.alarm.repository;
 import kr.pickple.back.alarm.domain.AlarmStatus;
 import kr.pickple.back.alarm.domain.CrewAlarm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +12,7 @@ public interface CrewAlarmRepository extends JpaRepository<CrewAlarm, Long> {
 
     boolean existsByMemberIdAndIsRead(final Long memberId, final AlarmStatus alarmStatus);
 
+    @Query("SELECT ca FROM CrewAlarm ca JOIN FETCH ca.crew WHERE ca.member.id = :memberId")
     List<CrewAlarm> findByMemberId(final Long memberId);
 
     void deleteByMemberId(final Long memberId);

--- a/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
@@ -4,11 +4,14 @@ import kr.pickple.back.alarm.domain.AlarmStatus;
 import kr.pickple.back.alarm.domain.GameAlarm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GameAlarmRepository extends JpaRepository<GameAlarm, Long> {
 
     boolean existsByMemberIdAndIsRead(final Long memberId, final AlarmStatus alarmStatus);
+
+    List<GameAlarm> findByMemberId(final Long memberId);
 
     void deleteByMemberId(final Long memberId);
 

--- a/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
@@ -20,16 +20,20 @@ public interface GameAlarmRepository extends JpaRepository<GameAlarm, Long> {
 
     @Query("SELECT ga " +
             "FROM GameAlarm ga LEFT JOIN FETCH ga.game " +
-            "WHERE ga.member.id = :memberId AND ga.id < :cursorId " +
+            "WHERE ga.member.id = :memberId " +
             "ORDER BY ga.createdAt DESC")
-    List<GameAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
-                                                                    @Param("cursorId") final Long cuserId,
-                                                                    final PageRequest of);
+    List<GameAlarm> findByMemberIdOrderByCreatedAtDesc(
+            @Param("memberId") final Long loggedInMemberId,
+            final PageRequest of
+    );
 
     @Query("SELECT ga " +
             "FROM GameAlarm ga LEFT JOIN FETCH ga.game " +
-            "WHERE ga.member.id = :memberId " +
+            "WHERE ga.member.id = :memberId AND ga.id < :cursorId " +
             "ORDER BY ga.createdAt DESC")
-    List<GameAlarm> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
-                                                       final PageRequest of);
+    List<GameAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
+            @Param("memberId") final Long loggedInMemberId,
+            @Param("cursorId") final Long cursorId,
+            final PageRequest of
+    );
 }

--- a/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
@@ -2,8 +2,10 @@ package kr.pickple.back.alarm.repository;
 
 import kr.pickple.back.alarm.domain.AlarmStatus;
 import kr.pickple.back.alarm.domain.GameAlarm;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,10 +14,22 @@ public interface GameAlarmRepository extends JpaRepository<GameAlarm, Long> {
 
     boolean existsByMemberIdAndIsRead(final Long memberId, final AlarmStatus alarmStatus);
 
-    @Query("SELECT ga FROM GameAlarm ga JOIN FETCH ga.game WHERE ga.member.id = :memberId")
-    List<GameAlarm> findByMemberId(final Long memberId);
-
     void deleteByMemberId(final Long memberId);
 
     Optional<GameAlarm> findByMemberIdAndId(final Long memberId, final Long gameAlarmId);
+
+    @Query("SELECT ga " +
+            "FROM GameAlarm ga LEFT JOIN FETCH ga.game " +
+            "WHERE ga.member.id = :memberId AND ga.id < :cursorId " +
+            "ORDER BY ga.createdAt DESC")
+    List<GameAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
+                                                                    @Param("cursorId") final Long cuserId,
+                                                                    final PageRequest of);
+
+    @Query("SELECT ga " +
+            "FROM GameAlarm ga LEFT JOIN FETCH ga.game " +
+            "WHERE ga.member.id = :memberId " +
+            "ORDER BY ga.createdAt DESC")
+    List<GameAlarm> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") final Long loggedInMemberId,
+                                                       final PageRequest of);
 }

--- a/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
@@ -3,6 +3,7 @@ package kr.pickple.back.alarm.repository;
 import kr.pickple.back.alarm.domain.AlarmStatus;
 import kr.pickple.back.alarm.domain.GameAlarm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +12,7 @@ public interface GameAlarmRepository extends JpaRepository<GameAlarm, Long> {
 
     boolean existsByMemberIdAndIsRead(final Long memberId, final AlarmStatus alarmStatus);
 
+    @Query("SELECT ga FROM GameAlarm ga JOIN FETCH ga.game WHERE ga.member.id = :memberId")
     List<GameAlarm> findByMemberId(final Long memberId);
 
     void deleteByMemberId(final Long memberId);

--- a/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
@@ -1,6 +1,9 @@
 package kr.pickple.back.alarm.service;
 
 import kr.pickple.back.alarm.dto.response.AlarmExistStatusResponse;
+import kr.pickple.back.alarm.dto.response.AlarmResponse;
+import kr.pickple.back.alarm.dto.response.CrewAlarmResponse;
+import kr.pickple.back.alarm.dto.response.GameAlarmResponse;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberRepository;
@@ -8,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.*;
 
 import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
@@ -22,6 +27,23 @@ public class AlarmService {
 
     public SseEmitter subscribeToSse(final Long loggedInMemberId) {
         return sseEmitterService.subscribeToSse(loggedInMemberId);
+    }
+
+    public Map<String, Object> findAllAlarms(final Long loggedInMemberId) {
+        final List<AlarmResponse> alarms = new ArrayList<>();
+
+        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId);
+        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId);
+
+        alarms.addAll(crewAlarms);
+        alarms.addAll(gameAlarms);
+
+        alarms.sort(Comparator.comparing(AlarmResponse::getCreatedAt).reversed());
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("alarms", alarms);
+
+        return response;
     }
 
     @Transactional

--- a/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
@@ -31,11 +31,11 @@ public class AlarmService {
         return sseEmitterService.subscribeToSse(loggedInMemberId);
     }
 
-    public CursorResult<AlarmResponse> findAllAlarms(final Long loggedInMemberId, final Long cursorId, final int size) {
+    public CursorResult<AlarmResponse> findAllAlarms(final Long loggedInMemberId, final Long lastCrewAlarmId, final Long lastGameAlarmId, final int size) {
         final List<AlarmResponse> alarms = new ArrayList<>();
 
-        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, cursorId, size / 2 + 1);
-        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, cursorId, size / 2 + 1);
+        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, lastCrewAlarmId, size / 2 + 1);
+        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, lastGameAlarmId, size / 2 + 1);
 
         alarms.addAll(crewAlarms);
         alarms.addAll(gameAlarms);
@@ -51,7 +51,6 @@ public class AlarmService {
                 .hasNext(hasNext)
                 .build();
     }
-
 
     @Transactional
     public AlarmExistStatusResponse checkUnReadAlarms(final Long loggedInMemberId) {

--- a/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
@@ -4,6 +4,7 @@ import kr.pickple.back.alarm.dto.response.AlarmExistStatusResponse;
 import kr.pickple.back.alarm.dto.response.AlarmResponse;
 import kr.pickple.back.alarm.dto.response.CrewAlarmResponse;
 import kr.pickple.back.alarm.dto.response.GameAlarmResponse;
+import kr.pickple.back.alarm.util.CursorResult;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberRepository;
@@ -12,14 +13,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class AlarmService {
-
     private final GameAlarmService gameAlarmService;
     private final CrewAlarmService crewAlarmService;
     private final MemberRepository memberRepository;
@@ -29,22 +31,27 @@ public class AlarmService {
         return sseEmitterService.subscribeToSse(loggedInMemberId);
     }
 
-    public Map<String, Object> findAllAlarms(final Long loggedInMemberId) {
+    public CursorResult<AlarmResponse> findAllAlarms(final Long loggedInMemberId, final Long cursorId, final int size) {
         final List<AlarmResponse> alarms = new ArrayList<>();
 
-        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId);
-        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId);
+        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, cursorId, size / 2 + 1);
+        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, cursorId, size / 2 + 1);
 
         alarms.addAll(crewAlarms);
         alarms.addAll(gameAlarms);
-
         alarms.sort(Comparator.comparing(AlarmResponse::getCreatedAt).reversed());
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("alarms", alarms);
+        final Boolean hasNext = alarms.size() > size;
+        while (alarms.size() > size) {
+            alarms.remove(alarms.size() - 1);
+        }
 
-        return response;
+        return CursorResult.<AlarmResponse>builder()
+                .alarmResponse(alarms)
+                .hasNext(hasNext)
+                .build();
     }
+
 
     @Transactional
     public AlarmExistStatusResponse checkUnReadAlarms(final Long loggedInMemberId) {

--- a/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
@@ -15,13 +15,11 @@ import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static kr.pickple.back.alarm.domain.AlarmStatus.FALSE;
@@ -31,7 +29,6 @@ import static kr.pickple.back.crew.exception.CrewExceptionCode.CREW_IS_NOT_LEADE
 import static kr.pickple.back.crew.exception.CrewExceptionCode.CREW_NOT_FOUND;
 import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CrewAlarmService {
@@ -123,17 +120,21 @@ public class CrewAlarmService {
         }
     }
 
-    public List<CrewAlarmResponse> findByMemberId(final Long loggedInMemberId, final Long cursorId, final int size) {
-        final List<CrewAlarm> crewAlarms = Optional.ofNullable(cursorId)
-                .map(id -> crewAlarmRepository.findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
-                        loggedInMemberId,
-                        id,
-                        PageRequest.of(0, size)
-                ))
-                .orElse(crewAlarmRepository.findByMemberIdOrderByCreatedAtDesc(
-                        loggedInMemberId,
-                        PageRequest.of(0, size)
-                ));
+    public List<CrewAlarmResponse> findByMemberId(final Long loggedInMemberId, final Long lastCrewAlarmId, final int size) {
+        final List<CrewAlarm> crewAlarms;
+
+        if (lastCrewAlarmId == null) {
+            crewAlarms = crewAlarmRepository.findByMemberIdOrderByCreatedAtDesc(
+                    loggedInMemberId,
+                    PageRequest.of(0, size)
+            );
+        } else {
+            crewAlarms = crewAlarmRepository.findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
+                    loggedInMemberId,
+                    lastCrewAlarmId,
+                    PageRequest.of(0, size)
+            );
+        }
 
         return crewAlarms.stream()
                 .map(CrewAlarmResponse::from)

--- a/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
@@ -16,10 +16,12 @@ import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static kr.pickple.back.alarm.domain.AlarmStatus.FALSE;
@@ -121,8 +123,17 @@ public class CrewAlarmService {
         }
     }
 
-    public List<CrewAlarmResponse> findByMemberId(final Long loggedInMemberId) {
-        final List<CrewAlarm> crewAlarms = crewAlarmRepository.findByMemberId(loggedInMemberId);
+    public List<CrewAlarmResponse> findByMemberId(final Long loggedInMemberId, final Long cursorId, final int size) {
+        final List<CrewAlarm> crewAlarms = Optional.ofNullable(cursorId)
+                .map(id -> crewAlarmRepository.findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
+                        loggedInMemberId,
+                        id,
+                        PageRequest.of(0, size)
+                ))
+                .orElse(crewAlarmRepository.findByMemberIdOrderByCreatedAtDesc(
+                        loggedInMemberId,
+                        PageRequest.of(0, size)
+                ));
 
         return crewAlarms.stream()
                 .map(CrewAlarmResponse::from)

--- a/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
@@ -108,6 +108,7 @@ public class CrewAlarmService {
     private Member getMemberInfo(final Long memberId) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND, memberId));
+
         return member;
     }
 

--- a/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
@@ -19,6 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static kr.pickple.back.alarm.domain.AlarmStatus.FALSE;
 import static kr.pickple.back.alarm.domain.CrewAlarmType.*;
 import static kr.pickple.back.alarm.exception.AlarmExceptionCode.ALARM_NOT_FOUND;
@@ -115,6 +118,14 @@ public class CrewAlarmService {
         if (!crew.isLeader(crewAlarmEvent.getMemberId())) {
             throw new CrewException(CREW_IS_NOT_LEADER, crewId, crew.getLeader());
         }
+    }
+
+    public List<CrewAlarmResponse> findByMemberId(final Long loggedInMemberId) {
+        final List<CrewAlarm> crewAlarms = crewAlarmRepository.findByMemberId(loggedInMemberId);
+
+        return crewAlarms.stream()
+                .map(CrewAlarmResponse::from)
+                .collect(Collectors.toList());
     }
 
     public boolean checkUnreadCrewAlarm(final Long memberId) {

--- a/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/CrewAlarmService.java
@@ -120,10 +120,10 @@ public class CrewAlarmService {
         }
     }
 
-    public List<CrewAlarmResponse> findByMemberId(final Long loggedInMemberId, final Long lastCrewAlarmId, final int size) {
+    public List<CrewAlarmResponse> findByMemberId(final Long loggedInMemberId, final Long cursorId, final int size) {
         final List<CrewAlarm> crewAlarms;
 
-        if (lastCrewAlarmId == null) {
+        if (cursorId == null) {
             crewAlarms = crewAlarmRepository.findByMemberIdOrderByCreatedAtDesc(
                     loggedInMemberId,
                     PageRequest.of(0, size)
@@ -131,7 +131,7 @@ public class CrewAlarmService {
         } else {
             crewAlarms = crewAlarmRepository.findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
                     loggedInMemberId,
-                    lastCrewAlarmId,
+                    cursorId,
                     PageRequest.of(0, size)
             );
         }

--- a/src/main/java/kr/pickple/back/alarm/service/GameAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/GameAlarmService.java
@@ -19,6 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static kr.pickple.back.alarm.domain.AlarmStatus.FALSE;
 import static kr.pickple.back.alarm.domain.GameAlarmType.*;
 import static kr.pickple.back.alarm.exception.AlarmExceptionCode.ALARM_NOT_FOUND;
@@ -35,6 +38,7 @@ public class GameAlarmService {
     private final GameRepository gameRepository;
     private final GameAlarmRepository gameAlarmRepository;
     private final SseEmitterService sseEmitterService;
+
 
     @Transactional
     public void createGameJoinAlarm(final GameJoinRequestNotificationEvent gameJoinRequestNotificationEvent) {
@@ -114,6 +118,14 @@ public class GameAlarmService {
     private Member getMemberInfo(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND, memberId));
+    }
+
+    public List<GameAlarmResponse> findByMemberId(final Long loggedInMemberId) {
+        final List<GameAlarm> gameAlarms = gameAlarmRepository.findByMemberId(loggedInMemberId);
+
+        return gameAlarms.stream()
+                .map(GameAlarmResponse::from)
+                .collect(Collectors.toList());
     }
 
     public boolean checkUnreadGameAlarm(final Long memberId) {

--- a/src/main/java/kr/pickple/back/alarm/service/GameAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/GameAlarmService.java
@@ -39,7 +39,6 @@ public class GameAlarmService {
     private final GameAlarmRepository gameAlarmRepository;
     private final SseEmitterService sseEmitterService;
 
-
     @Transactional
     public void createGameJoinAlarm(final GameJoinRequestNotificationEvent gameJoinRequestNotificationEvent) {
 

--- a/src/main/java/kr/pickple/back/alarm/service/GameAlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/GameAlarmService.java
@@ -118,10 +118,10 @@ public class GameAlarmService {
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND, memberId));
     }
 
-    public List<GameAlarmResponse> findByMemberId(final Long loggedInMemberId, final Long lastGameAlarmId, final int size) {
+    public List<GameAlarmResponse> findByMemberId(final Long loggedInMemberId, final Long cursorId, final int size) {
         final List<GameAlarm> gameAlarms;
 
-        if (lastGameAlarmId == null) {
+        if (cursorId == null) {
             gameAlarms = gameAlarmRepository.findByMemberIdOrderByCreatedAtDesc(
                     loggedInMemberId,
                     PageRequest.of(0, size)
@@ -129,7 +129,7 @@ public class GameAlarmService {
         } else {
             gameAlarms = gameAlarmRepository.findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
                     loggedInMemberId,
-                    lastGameAlarmId,
+                    cursorId,
                     PageRequest.of(0, size)
             );
         }

--- a/src/main/java/kr/pickple/back/alarm/util/CursorResult.java
+++ b/src/main/java/kr/pickple/back/alarm/util/CursorResult.java
@@ -13,6 +13,6 @@ import java.util.List;
 @AllArgsConstructor
 public class CursorResult<T> {
 
-    private List<T> alarmResponses;
+    private List<T> alarmResponse;
     private Boolean hasNext;
 }

--- a/src/main/java/kr/pickple/back/alarm/util/CursorResult.java
+++ b/src/main/java/kr/pickple/back/alarm/util/CursorResult.java
@@ -15,4 +15,5 @@ public class CursorResult<T> {
 
     private List<T> alarmResponse;
     private Boolean hasNext;
+    private Long cursorId;
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 크루 알림, 게임알림을 하나의 페이지 안에서 생성일을 기준으로 조회할 수 있게 한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] 크루 알림 목록 조회
- [X] 게임 알림 목록 조회
- [X] 크루 알림 목록 조회와 게임 알람 목록 조회를 통합
- [X] 커서 기반 페이징

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 크루 알림과 게임알림을 해당 사용자에게 한 목록 안에서 볼 수 있도록 구현하였습니다!
- 크루 알림과 게임알림을 합쳐, 최신순으로 출력하도록 구현하였습니다!
- 지연로딩이 발생되어 JPQL을 사용하였습니다!
- 해당 코드 중간에 120자가 넘는 줄이 있어, 다음 줄로 개행하도록 했습니다!
