### PR TITLE
[#212] 크루 거절, 게임 거절 알람 이벤트 발생 부분 리팩토링 

### DIFF
--- a/src/main/java/kr/pickple/back/alarm/config/AsynConfig.java
+++ b/src/main/java/kr/pickple/back/alarm/config/AsynConfig.java
@@ -1,5 +1,7 @@
 package kr.pickple.back.alarm.config;
 
+import kr.pickple.back.common.config.property.AsyncProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
@@ -8,14 +10,17 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
+@RequiredArgsConstructor
 public class AsynConfig {
+
+    private final AsyncProperties asyncProperties;
 
     @Bean
     public TaskExecutor taskExecutor() {
         return CustomThreadPoolTaskExecutor.builder()
-                .corePoolSize(30)
-                .maxPoolSize(50)
-                .queueCapacity(70)
+                .corePoolSize(asyncProperties.getCorePoolSize())
+                .maxPoolSize(asyncProperties.getMaxPoolSize())
+                .queueCapacity(asyncProperties.getQueueCapacity())
                 .build();
     }
 

--- a/src/main/java/kr/pickple/back/common/config/CommonConfig.java
+++ b/src/main/java/kr/pickple/back/common/config/CommonConfig.java
@@ -1,12 +1,13 @@
 package kr.pickple.back.common.config;
 
+import kr.pickple.back.common.config.property.AsyncProperties;
 import kr.pickple.back.common.config.property.RedisProperties;
 import kr.pickple.back.common.config.property.S3Properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(value = {RedisProperties.class, S3Properties.class})
+@EnableConfigurationProperties(value = {RedisProperties.class, S3Properties.class, AsyncProperties.class})
 public class CommonConfig {
 
 }

--- a/src/main/java/kr/pickple/back/common/config/property/AsyncProperties.java
+++ b/src/main/java/kr/pickple/back/common/config/property/AsyncProperties.java
@@ -1,5 +1,6 @@
 package kr.pickple.back.common.config.property;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,10 +10,11 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ConfigurationProperties(prefix = "async")
 public class AsyncProperties {
-    private int corePoolSize;
-    private int maxPoolSize;
-    private int queueCapacity;
+
+    private Integer corePoolSize;
+    private Integer maxPoolSize;
+    private Integer queueCapacity;
 }

--- a/src/main/java/kr/pickple/back/common/config/property/AsyncProperties.java
+++ b/src/main/java/kr/pickple/back/common/config/property/AsyncProperties.java
@@ -1,0 +1,18 @@
+package kr.pickple.back.common.config.property;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@NoArgsConstructor
+@ConfigurationProperties(prefix = "async")
+public class AsyncProperties {
+    private int corePoolSize;
+    private int maxPoolSize;
+    private int queueCapacity;
+}

--- a/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
@@ -125,12 +125,12 @@ public class CrewMemberService {
         if (crew.isLeader(loggedInMemberId)) {
             validateIsLeaderSelfDeleted(loggedInMemberId, memberId);
 
-            deleteCrewMember(crewMember);
-
             eventPublisher.publishEvent(CrewMemberRejectedEvent.builder()
                     .crewId(crewId)
                     .memberId(memberId)
                     .build());
+
+            deleteCrewMember(crewMember);
             return;
         }
 

--- a/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
@@ -131,6 +131,7 @@ public class CrewMemberService {
                     .build());
 
             deleteCrewMember(crewMember);
+
             return;
         }
 

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -215,12 +215,12 @@ public class GameService {
         if (game.isHost(loggedInMember)) {
             validateIsHostSelfDeleted(loggedInMember, member);
 
-            deleteGameMember(gameMember);
-
             eventPublisher.publishEvent(GameMemberRejectedEvent.builder()
                     .gameId(gameId)
                     .memberId(memberId)
                     .build());
+
+            deleteGameMember(gameMember);
             return;
         }
 

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -221,6 +221,7 @@ public class GameService {
                     .build());
 
             deleteGameMember(gameMember);
+
             return;
         }
 


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  크루 거절 알람 이벤트 발생 부분 리팩토링
- [X] 게임 거절 알람 이벤트 발생 부분 리팩토링
- [X] 비동기 로직의 매직넘버 제거

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
- 기존의 크루 거절, 게임 거절의 알람 이벤트 발생 부분을 수정한다.
- 비동기 로직의 매직넘버를 제거한다.

---

### 기타
<!-- 작성하지 않으면 삭제 -->

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
