### PR TITLE
[#230] 조건별(장소, 날짜, 포지션별) 게스트 모집글 조회 기능에서 종료된 경기는 조회되지 않도록 수정

### DIFF
--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -187,6 +187,10 @@ public class Game extends BaseEntity {
         return status == CLOSED;
     }
 
+    public Boolean isNotEndedGame() {
+        return status != ENDED;
+    }
+
     private Boolean isFullGame() {
         return memberCount.equals(maxMemberCount);
     }

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -1,5 +1,21 @@
 package kr.pickple.back.game.service;
 
+import static kr.pickple.back.chat.domain.RoomType.*;
+import static kr.pickple.back.common.domain.RegistrationStatus.*;
+import static kr.pickple.back.game.exception.GameExceptionCode.*;
+import static kr.pickple.back.member.exception.MemberExceptionCode.*;
+
+import java.text.MessageFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.locationtech.jts.geom.Point;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.pickple.back.address.dto.response.MainAddressResponse;
 import kr.pickple.back.address.service.AddressService;
 import kr.pickple.back.address.service.kakao.KakaoAddressSearchClient;
@@ -28,22 +44,6 @@ import kr.pickple.back.member.dto.response.MemberResponse;
 import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Point;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.text.MessageFormat;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-
-import static kr.pickple.back.chat.domain.RoomType.GAME;
-import static kr.pickple.back.common.domain.RegistrationStatus.CONFIRMED;
-import static kr.pickple.back.common.domain.RegistrationStatus.WAITING;
-import static kr.pickple.back.game.exception.GameExceptionCode.*;
-import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -155,6 +155,7 @@ public class GameService {
         );
 
         return games.stream()
+                .filter(Game::isNotEndedGame)
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
                 .toList();
     }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 현재 종료된 경기도 응답이 되고 있음.
- 종료된 경기는 응답되지 않도록 수정.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 조건별(장소, 날짜, 포지션별) 게스트 모집글 조회에서 종료된 경기는 응답되지 않도록 수정



---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
