### PR TITLE
[#235] 알람 목록 조회 커서 id , hasNext 에러 수정

### DIFF
--- a/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
+++ b/src/main/java/kr/pickple/back/alarm/controller/AlarmController.java
@@ -49,11 +49,12 @@ public class AlarmController {
     @GetMapping
     public ResponseEntity<CursorResult<AlarmResponse>> findAllAlarms(
             @Login final Long loggedInMemberId,
-            @RequestParam(value = "cursorId", required = false) Long cursorId,
-            @RequestParam(value = "size", defaultValue = "6") int size
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "6") Integer size
     ) {
         final CursorResult<AlarmResponse> result = alarmService.findAllAlarms(
                 loggedInMemberId, cursorId, size);
+
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
+++ b/src/main/java/kr/pickple/back/alarm/dto/response/AlarmResponse.java
@@ -3,6 +3,8 @@ package kr.pickple.back.alarm.dto.response;
 import java.time.LocalDateTime;
 
 public interface AlarmResponse {
+
     LocalDateTime getCreatedAt();
+
     Long getAlarmId();
 }

--- a/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/CrewAlarmRepository.java
@@ -23,7 +23,7 @@ public interface CrewAlarmRepository extends JpaRepository<CrewAlarm, Long> {
             "ORDER BY ca.createdAt DESC")
     List<CrewAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
             @Param("memberId") final Long loggedInMemberId,
-            @Param("cursorId") final Long cursorId,
+            final Long cursorId,
             final PageRequest of
     );
 

--- a/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/GameAlarmRepository.java
@@ -32,7 +32,7 @@ public interface GameAlarmRepository extends JpaRepository<GameAlarm, Long> {
             "ORDER BY ga.createdAt DESC")
     List<GameAlarm> findByMemberIdAndIdLessThanOrderByCreatedAtDesc(
             @Param("memberId") final Long loggedInMemberId,
-            @Param("cursorId") final Long cursorId,
+            final Long cursorId,
             final PageRequest of
     );
 }

--- a/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
@@ -34,7 +34,7 @@ public class AlarmService {
 
     public CursorResult<AlarmResponse> findAllAlarms(final Long loggedInMemberId, final Long cursorId, final Integer size) {
         final List<AlarmResponse> alarms = new ArrayList<>();
-        final int checkSizeForNextPage = size + 1;
+        final Integer checkSizeForNextPage = size + 1;
 
         final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, Optional.ofNullable(cursorId), checkSizeForNextPage);
         final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, Optional.ofNullable(cursorId), checkSizeForNextPage);
@@ -46,10 +46,10 @@ public class AlarmService {
         Boolean hasNext = alarms.size() > size;
         Long nextCursorId = null;
 
-        if (alarms.size() > size) {
-            hasNext = true;
+        if (hasNext) {
             AlarmResponse lastAlarm = alarms.remove(size.intValue());
             nextCursorId = lastAlarm.getAlarmId();
+            hasNext = alarms.size() > size;
         }
 
         return CursorResult.<AlarmResponse>builder()

--- a/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
@@ -34,23 +34,20 @@ public class AlarmService {
     public CursorResult<AlarmResponse> findAllAlarms(final Long loggedInMemberId, final Long cursorId, final int size) {
         final List<AlarmResponse> alarms = new ArrayList<>();
 
-        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, cursorId, size / 2 + 1);
-        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, cursorId, size / 2 + 1);
+        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, cursorId, size + 1);
+        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, cursorId, size + 1);
 
         alarms.addAll(crewAlarms);
         alarms.addAll(gameAlarms);
         alarms.sort(Comparator.comparing(AlarmResponse::getCreatedAt).reversed());
 
-        final Boolean hasNext = alarms.size() > size;
+        Boolean hasNext = alarms.size() > size;
         Long nextCursorId = null;
 
-        if (hasNext) {
-            AlarmResponse lastAlarm = alarms.remove(alarms.size() - 1);
+        if (alarms.size() > size) {
+            hasNext = true;
+            AlarmResponse lastAlarm = alarms.remove(size);
             nextCursorId = lastAlarm.getAlarmId();
-        }
-
-        while (alarms.size() > size) {
-            alarms.remove(alarms.size() - 1);
         }
 
         return CursorResult.<AlarmResponse>builder()

--- a/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
+++ b/src/main/java/kr/pickple/back/alarm/service/AlarmService.java
@@ -16,6 +16,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
@@ -31,11 +32,12 @@ public class AlarmService {
         return sseEmitterService.subscribeToSse(loggedInMemberId);
     }
 
-    public CursorResult<AlarmResponse> findAllAlarms(final Long loggedInMemberId, final Long cursorId, final int size) {
+    public CursorResult<AlarmResponse> findAllAlarms(final Long loggedInMemberId, final Long cursorId, final Integer size) {
         final List<AlarmResponse> alarms = new ArrayList<>();
+        final int checkSizeForNextPage = size + 1;
 
-        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, cursorId, size + 1);
-        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, cursorId, size + 1);
+        final List<CrewAlarmResponse> crewAlarms = crewAlarmService.findByMemberId(loggedInMemberId, Optional.ofNullable(cursorId), checkSizeForNextPage);
+        final List<GameAlarmResponse> gameAlarms = gameAlarmService.findByMemberId(loggedInMemberId, Optional.ofNullable(cursorId), checkSizeForNextPage);
 
         alarms.addAll(crewAlarms);
         alarms.addAll(gameAlarms);
@@ -46,7 +48,7 @@ public class AlarmService {
 
         if (alarms.size() > size) {
             hasNext = true;
-            AlarmResponse lastAlarm = alarms.remove(size);
+            AlarmResponse lastAlarm = alarms.remove(size.intValue());
             nextCursorId = lastAlarm.getAlarmId();
         }
 


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 알람 목록 조회 시 커서 id가 null 로 보이는 에러, hasNext가 항상 fasle로 보이는 에러를 수정한다.
- 피드백을 받은 리팩토링 과정도 함께 진행했습니다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  커서 id가 null로 보이는 에러
- [X] hasNext가 항상 false로 보이는 에러를 수정한다.
