### PR TITLE
[#237] 실시간 크루 알람, 게임 알람 메시지가 오지 않는 에러 수정

### DIFF
--- a/src/main/java/kr/pickple/back/alarm/repository/SseEmitterLocalRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/SseEmitterLocalRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -26,6 +27,11 @@ public class SseEmitterLocalRepository implements SseEmitterRepository {
     @Override
     public void saveEventCache(final String eventCacheId, final Object event) {
         fallbackEmitters.put(Long.parseLong(eventCacheId), event);
+    }
+
+    @Override
+    public Optional<SseEmitter> findById(final Long emitterId) {
+        return Optional.ofNullable(emitters.get(emitterId));
     }
 
     @Override

--- a/src/main/java/kr/pickple/back/alarm/repository/SseEmitterRepository.java
+++ b/src/main/java/kr/pickple/back/alarm/repository/SseEmitterRepository.java
@@ -3,12 +3,15 @@ package kr.pickple.back.alarm.repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Map;
+import java.util.Optional;
 
 public interface SseEmitterRepository {
 
     SseEmitter save(final String emitterId, final SseEmitter sseEmitter);
 
     void saveEventCache(final String eventCacheId, final Object event);
+
+    Optional<SseEmitter> findById(final Long emitterId);
 
     void deleteEventCache(final String eventCacheId);
 


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 사용자가 SSE 연결 시 실시간 크루 알람, 게임 알람 메시지가 오지 않는 에러를 해결한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] 사용자가 SSE 연결 시 실시간 크루 알람, 게임 알람 메시지가 오지 않는 에러를 해결

