### PR TITLE
[#247] 지도에서 종료된 게스트 모집글을 불러오는 현상 해결

### DIFF
--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -312,6 +312,7 @@ public class GameService {
         final List<Game> games = gameRepository.findGamesWithInDistance(latitude, longitude, distance);
 
         return games.stream()
+                .filter(Game::isNotEndedGame)
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
                 .toList();
     }
@@ -323,6 +324,7 @@ public class GameService {
         );
 
         return games.stream()
+                .filter(Game::isNotEndedGame)
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
                 .toList();
     }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 지도에서 게스트 모집글을 불러올 때 경기가 종료되지 않은 데이터만 불러올 수 있도록 수정한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] isNotEndedGame 메서드를 filter에 추가

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->

---

### 기타
<!-- 작성하지 않으면 삭제 -->

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
