### PR TITLE
[#259] 조건별 게스트 모집글 조회 시, 빈 배열이 반환되는 현상 해결

### DIFF
--- a/src/main/java/kr/pickple/back/game/repository/GameRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameRepository.java
@@ -17,9 +17,10 @@ import kr.pickple.back.game.domain.GameStatus;
 
 public interface GameRepository extends JpaRepository<Game, Long>, GameSearchRepository {
 
-    Page<Game> findByAddressDepth1AndAddressDepth2(
+    Page<Game> findByAddressDepth1AndAddressDepth2AndStatusNot(
             final AddressDepth1 addressDepth1,
             final AddressDepth2 addressDepth2,
+            final GameStatus status,
             final Pageable pageable
     );
 

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -32,6 +32,7 @@ import kr.pickple.back.common.util.DateTimeUtil;
 import kr.pickple.back.game.domain.Category;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.game.domain.GameMember;
+import kr.pickple.back.game.domain.GameStatus;
 import kr.pickple.back.game.dto.request.GameCreateRequest;
 import kr.pickple.back.game.dto.request.GameMemberRegistrationStatusUpdateRequest;
 import kr.pickple.back.game.dto.request.MannerScoreReview;
@@ -160,14 +161,14 @@ public class GameService {
                 )
         );
 
-        final Page<Game> games = gameRepository.findByAddressDepth1AndAddressDepth2(
+        final Page<Game> games = gameRepository.findByAddressDepth1AndAddressDepth2AndStatusNot(
                 mainAddressResponse.getAddressDepth1(),
                 mainAddressResponse.getAddressDepth2(),
+                GameStatus.ENDED,
                 pageRequest
         );
 
         return games.stream()
-                .filter(Game::isNotEndedGame)
                 .map(game -> GameResponse.of(game, getMemberResponses(game, CONFIRMED)))
                 .toList();
     }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 조건별 게스트 모집글을 조회할 때, 모집 중인 게스트 모집글이 있음에도 불구하고 반환이 되지 않는 현상을 해결한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] GameStatus가 ENDED가 아니라는 조건을 커스텀 쿼리에 추가

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
