### PR TITLE
[#261] 크루 기본 프로필 사진, 기본 배경사진 랜덤 지정

### DIFF
--- a/src/main/http/ranking/ranking.http
+++ b/src/main/http/ranking/ranking.http
@@ -1,0 +1,2 @@
+### 크루 랭킹 조회
+GET http://localhost:8080/ranking/crews

--- a/src/main/java/kr/pickple/back/common/config/property/S3Properties.java
+++ b/src/main/java/kr/pickple/back/common/config/property/S3Properties.java
@@ -9,6 +9,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "s3.default")
 public class S3Properties {
 
-    private final String profile;
-    private final String background;
+    private final String crewProfile;
+    private final String crewBackground;
 }

--- a/src/main/java/kr/pickple/back/common/util/RandomUtil.java
+++ b/src/main/java/kr/pickple/back/common/util/RandomUtil.java
@@ -1,0 +1,12 @@
+package kr.pickple.back.common.util;
+
+import java.util.Random;
+
+public final class RandomUtil {
+
+    public static int getRandomNumber(final int start, final int end) {
+        final Random random = new Random();
+
+        return random.nextInt(end) + start;
+    }
+}

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -1,10 +1,24 @@
 package kr.pickple.back.crew.service;
 
+import static kr.pickple.back.chat.domain.RoomType.*;
+import static kr.pickple.back.common.domain.RegistrationStatus.*;
+import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
+import static kr.pickple.back.member.exception.MemberExceptionCode.*;
+
+import java.text.MessageFormat;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.pickple.back.address.dto.response.MainAddressResponse;
 import kr.pickple.back.address.service.AddressService;
 import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.chat.service.ChatRoomService;
 import kr.pickple.back.common.config.property.S3Properties;
+import kr.pickple.back.common.util.RandomUtil;
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.dto.request.CrewCreateRequest;
 import kr.pickple.back.crew.dto.response.CrewIdResponse;
@@ -17,24 +31,14 @@ import kr.pickple.back.member.dto.response.MemberResponse;
 import kr.pickple.back.member.exception.MemberException;
 import kr.pickple.back.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static kr.pickple.back.chat.domain.RoomType.CREW;
-import static kr.pickple.back.common.domain.RegistrationStatus.CONFIRMED;
-import static kr.pickple.back.crew.exception.CrewExceptionCode.CREW_CREATE_MAX_COUNT_EXCEEDED;
-import static kr.pickple.back.crew.exception.CrewExceptionCode.CREW_IS_EXISTED;
-import static kr.pickple.back.member.exception.MemberExceptionCode.MEMBER_NOT_FOUND;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CrewService {
 
+    private static final Integer CREW_IMAGE_START_NUMBER = 1;
+    private static final Integer CREW_IMAGE_END_NUMBER = 20;
     private static final Integer CREW_CREATE_MAX_SIZE = 3;
 
     private final S3Properties s3Properties;
@@ -57,11 +61,14 @@ public class CrewService {
                 crewCreateRequest.getAddressDepth2()
         );
 
+        final Integer crewImageRandomNumber = RandomUtil.getRandomNumber(CREW_IMAGE_START_NUMBER,
+                CREW_IMAGE_END_NUMBER);
+
         final Crew crew = crewCreateRequest.toEntity(
                 leader,
                 mainAddressResponse,
-                s3Properties.getProfile(),
-                s3Properties.getBackground()
+                MessageFormat.format(s3Properties.getCrewProfile(), crewImageRandomNumber),
+                MessageFormat.format(s3Properties.getCrewBackground(), crewImageRandomNumber)
         );
         crew.addCrewMember(leader);
 

--- a/src/main/java/kr/pickple/back/ranking/repository/RankingJdbcRepository.java
+++ b/src/main/java/kr/pickple/back/ranking/repository/RankingJdbcRepository.java
@@ -26,8 +26,7 @@ public class RankingJdbcRepository {
                 crew_ranking.manner_score, 
                 crew_ranking.activity_score + crew_ranking.manner_score AS total_score, 
                 RANK() OVER (
-                    ORDER BY crew_ranking.manner_score + crew_ranking.activity_score DESC, 
-                    crew_ranking.name
+                    ORDER BY crew_ranking.manner_score + crew_ranking.activity_score DESC
                 ) AS ranking 
             FROM (
                 SELECT 


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 현재 1개의 기본 이미지로 되어 있는 크루 이미지 지정 부분을 다양하게 변경한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] S3 관련 환경변수 변경
- [x] 크루 생성 시 랜덤 선택 로직 추가

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
