### PR TITLE
[#263] 현재 채팅방에 있는 사용자 목록 조회 시 Active 사용자만 불러오도록 변경

### DIFF
--- a/src/main/java/kr/pickple/back/chat/domain/ChatRoom.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatRoom.java
@@ -124,8 +124,8 @@ public class ChatRoom extends BaseEntity {
         return chatMessages.getChatMessages();
     }
 
-    public List<Member> getMembersInRoom() {
-        return chatRoomMembers.getMembers();
+    public List<Member> getActiveMembersInRoom() {
+        return chatRoomMembers.getActiveMembers();
     }
 
     public ChatMessage getLastChatMessage() {

--- a/src/main/java/kr/pickple/back/chat/domain/ChatRoomMembers.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatRoomMembers.java
@@ -56,8 +56,9 @@ public class ChatRoomMembers {
                 .anyMatch(chatRoomMember -> member.equals(chatRoomMember.getMember()));
     }
 
-    List<Member> getMembers() {
+    List<Member> getActiveMembers() {
         return chatRoomMembers.stream()
+                .filter(ChatRoomMember::isActive)
                 .map(ChatRoomMember::getMember)
                 .toList();
     }

--- a/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/ChatRoomDetailResponse.java
@@ -75,7 +75,7 @@ public class ChatRoomDetailResponse {
     }
 
     private static List<ChatMemberResponse> getChatMemberResponses(final ChatRoom chatRoom) {
-        return chatRoom.getMembersInRoom()
+        return chatRoom.getActiveMembersInRoom()
                 .stream()
                 .map(ChatMemberResponse::from)
                 .toList();

--- a/src/main/java/kr/pickple/back/chat/service/ChatRoomFindService.java
+++ b/src/main/java/kr/pickple/back/chat/service/ChatRoomFindService.java
@@ -76,7 +76,7 @@ public class ChatRoomFindService {
     private ChatRoomDetailResponse getPersonalChatRoomDetailResponse(final Long memberId, final ChatRoom chatRoom) {
         final Member sender = findMemberById(memberId);
 
-        final Member receiver = chatRoom.getMembersInRoom()
+        final Member receiver = chatRoom.getActiveMembersInRoom()
                 .stream()
                 .filter(roomMember -> !roomMember.equals(sender))
                 .findFirst()


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 현재 채팅방에 있는 사용자 목록을 조회할 때 active가 아닌 사용자도 불러와지는 버그를 해결한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] active만 조회하도록 변경

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
