### PR TITLE
[#249] 크루 랭킹의 캐시 저장소 변경, 캐싱 스케줄러의 중복 실행 방지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation "com.github.ben-manes.caffeine:caffeine:3.1.8"
     implementation 'org.hibernate:hibernate-spatial:6.3.1.Final'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.4'
 
     implementation group: 'org.flywaydb', name: 'flyway-mysql', version: '9.10.2'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/kr/pickple/back/common/config/CacheConfig.java
+++ b/src/main/java/kr/pickple/back/common/config/CacheConfig.java
@@ -4,6 +4,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
@@ -70,6 +73,18 @@ public class CacheConfig {
                 .fromConnectionFactory(redisConnectionFactory())
                 .cacheDefaults(redisCacheConfiguration)
                 .build();
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config redisConfig = new Config();
+        redisConfig.useSingleServer()
+                .setAddress(String.format("redis://%s:%d", redisProperties.getHost(), redisProperties.getPort()))
+                .setPassword(redisProperties.getPassword())
+                .setConnectionMinimumIdleSize(2)
+                .setConnectionPoolSize(4);
+
+        return Redisson.create(redisConfig);
     }
 
     @Bean

--- a/src/main/java/kr/pickple/back/ranking/service/RankingService.java
+++ b/src/main/java/kr/pickple/back/ranking/service/RankingService.java
@@ -18,12 +18,12 @@ public class RankingService {
 
     private final RankingJdbcRepository rankingJdbcRepository;
 
-    @Cacheable(cacheManager = "caffeineCacheManager", cacheNames = "ranking", key = "'crew'")
+    @Cacheable(cacheManager = "redisCacheManager", cacheNames = "ranking", key = "'crew'")
     public List<CrewRankingResponse> findCrewRanking() {
         return putCrewRankingCache();
     }
 
-    @CachePut(cacheManager = "caffeineCacheManager", cacheNames = "ranking", key = "'crew'")
+    @CachePut(cacheManager = "redisCacheManager", cacheNames = "ranking", key = "'crew'")
     public List<CrewRankingResponse> putCrewRankingCache() {
         final List<CrewRankingResponse> crewRankings = rankingJdbcRepository.getCrewRankings();
 


### PR DESCRIPTION
### 관련 PR 목록
[1. 크루 랭킹 기능](https://github.com/Java-and-Script/pickple-back/pull/216)
[2. 랭킹에 로컬 캐시 적용](https://github.com/Java-and-Script/pickple-back/pull/244)
[3. 크루 랭킹의 캐시 저장소 변경, 캐싱 스케줄러의 중복 실행 방지](https://github.com/Java-and-Script/pickple-back/pull/266)

## 👨‍💻 작업 사항

### 📑 PR 개요  
<!-- PR에 대한 간단한 개요를 작성 -->
- 스케일 아웃 환경에서 캐시의 정합성을 맞추기 위해 크루 랭킹의 캐시 저장소를 CaffeineCache에서 Redis로 변경 
(로컬 -> 글로벌)
- Redis분산락을 이용하여 스케일 아웃 환경에서 캐싱 스케줄러의 중복 실행 방지

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 스케일 아웃 환경에서 캐시의 정합성을 맞추기 위해 크루 랭킹의 캐시 저장소를 로컬에서 글로벌로 변경(CaffeineCache -> Redis)
- [x] 분산락을 이용하여 스케일 아웃 환경에서 캐싱 스케줄러의 중복 실행 방지 기능 구현

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
#### 캐시 저장소 변경 이유(로컬 -> 글로벌)
- 스케일 아웃 된 운영 환경에서 로컬 캐시의 정합성이 안 맞는 경우가 생길 수 있습니다.
  - 캐시의 갱신 작업이 일어날 때, 테이블 변경이 생겨서 찰나의 순간에 두 서버가 같은 쿼리를 통해 다른 결과를 받아온 경우.
  - 모종의 이유로 한 서버의 스케줄러가 작동하지 않아서 둘 중 하나의 서버만 캐시를 갱신한 경우 등.
- 크루 랭킹은 추후 경쟁 시스템과 연관이 생길 수 있어 도메인적으로 예민한 데이터이고, 메인 페이지에 표기되는 기능이기에 캐시 정합성이 좀 더 엄격하게 맞춰지면 좋겠다고 생각했습니다.

---

### 📀 관련 데이터 (화면, 테이블, API 등)
#### 화면
![image](https://github.com/Java-and-Script/pickple-back/assets/76809524/f4162dbf-efdc-45ea-92f9-3a358c52055f)


#### 테이블 명
- crew, member, game, crew_member, game_member 


#### API endpoint
- GET /ranking/crews

#### 반환 예시 

```
200 OK

[
  {
    "id": 14,
    "name": "노드크루",
    "memberCount": 10,
    "maxMemberCount": 15,
    "profileImageUrl": "pickpleCrewProfileImage.s3.ap-northeast-2.amazonaws.com",
    "addressDepth1": "서울시",
    "addressDepth2": "강남구",
    "crewActivityScore": 10000,
    "mannerScore": 10000,
    "totalScore": 20000,
    "rank": 1,
  },
  {
    "id": 9,
    "name": "하하크루",
    "memberCount": 3,
    "maxMemberCount": 10,
    "profileImageUrl": "pickpleCrewProfileImage.s3.ap-northeast-2.amazonaws.com",
    "addressDepth1": "서울시",
    "addressDepth2": "마포구",
    "crewActivityScore": 10000,
    "mannerScore": 5000,
    "totalScore": 15000,
    "rank": 2,
  },
  {
    "id": 142,
    "name": "룰루크루",
    "memberCount": 20,
    "maxMemberCount": 25,
    "profileImageUrl": "pickpleCrewProfileImage.s3.ap-northeast-2.amazonaws.com",
    "addressDepth1": "서울시",
    "addressDepth2": "동대문구",
    "crewActivityScore": 1000,
    "mannerScore": 5000,
    "totalScore": 6000,
    "rank": 3,
  },
  ...	
]
```
---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
