### PR TITLE
[#269] 경기 종료 후, 7일이 지나면 리뷰가 불가능하도록 예외 처리 추가

### DIFF
--- a/src/main/java/kr/pickple/back/chat/service/ChatValidator.java
+++ b/src/main/java/kr/pickple/back/chat/service/ChatValidator.java
@@ -83,6 +83,6 @@ public class ChatValidator {
     }
 
     private Boolean isGameNotOver(final Game game) {
-        return DateTimeUtil.isAfterThanNow(game.getPlayDate(), game.getPlayEndTime());
+        return DateTimeUtil.isAfterThanNow(game.getPlayEndDatetime());
     }
 }

--- a/src/main/java/kr/pickple/back/common/util/DateTimeUtil.java
+++ b/src/main/java/kr/pickple/back/common/util/DateTimeUtil.java
@@ -1,8 +1,6 @@
 package kr.pickple.back.common.util;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -10,11 +8,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DateTimeUtil {
 
-    public static boolean isAfterThanNow(final LocalDate date, final LocalTime time) {
-        final LocalDateTime datetime = LocalDateTime.of(date, time);
-        final LocalDateTime now = LocalDateTime.now();
-
-        return datetime.isAfter(now);
+    public static boolean isAfterThanNow(final LocalDateTime datetime) {
+        return datetime.isAfter(LocalDateTime.now());
     }
 
     public static boolean isEqualOrAfter(final LocalDateTime baseDateTime, final LocalDateTime targetDateTime) {

--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -4,6 +4,7 @@ import static kr.pickple.back.game.domain.GameStatus.*;
 import static kr.pickple.back.game.exception.GameExceptionCode.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -161,6 +162,10 @@ public class Game extends BaseEntity {
 
     public List<GameMember> getGameMembers() {
         return gameMembers.getGameMembers();
+    }
+
+    public LocalDateTime getPlayEndDatetime() {
+        return LocalDateTime.of(playDate, playEndTime);
     }
 
     public void addGameMember(final Member member) {

--- a/src/main/java/kr/pickple/back/game/exception/GameExceptionCode.java
+++ b/src/main/java/kr/pickple/back/game/exception/GameExceptionCode.java
@@ -19,7 +19,7 @@ public enum GameExceptionCode implements ExceptionCode {
     GAME_HOST_CANNOT_BE_DELETED(HttpStatus.BAD_REQUEST, "GAM-008", "호스트는 자신의 게스트 모집글에서 삭제될 수 없음"),
     GAME_MEMBER_STATUS_IS_NOT_WAITING(HttpStatus.BAD_REQUEST, "GAM-009", "해당 게스트 모집글에 참여 신청 대기 상태가 아니라면, 참여 신청을 취소할 수 없음"),
     GAME_NOT_ALLOWED_TO_DELETE_GAME_MEMBER(HttpStatus.FORBIDDEN, "GAM-010", "해당 사용자의 게스트 모집글 참여 신청을 거절 혹은 취소할 권한이 필요함"),
-    GAME_MEMBERS_CAN_REVIEW_AFTER_PLAYING(HttpStatus.BAD_REQUEST, "GAM-011", "경기 종료 이전에는 리뷰를 남길 수 없음"),
+    GAME_MEMBERS_CAN_REVIEW_DURING_POSSIBLE_PERIOD(HttpStatus.BAD_REQUEST, "GAM-011", "리뷰 가능 기간이 아님 (경기 종료 후부터 7일)"),
     GAME_MEMBER_CANNOT_REVIEW_SELF(HttpStatus.BAD_REQUEST, "GAM-012", "자기 자신에게 리뷰를 남길 수 없음"),
     GAME_CAPACITY_LIMIT_REACHED(HttpStatus.BAD_REQUEST, "GAM-013", "해당 게스트 모집글의 정원을 초과할 수 없음"),
     GAME_STATUS_IS_CLOSED(HttpStatus.BAD_REQUEST, "GAM-014", "해당 게스트 모집글은 모집중이 아님"),

--- a/src/test/java/kr/pickple/back/fixture/domain/GameFixtures.java
+++ b/src/test/java/kr/pickple/back/fixture/domain/GameFixtures.java
@@ -31,7 +31,7 @@ public class GameFixtures {
 
         return Game.builder()
                 .content("하이하이 즐겜 한 판해요")
-                .playDate(LocalDate.of(2023, 11, 10))
+                .playDate(LocalDate.now().minusDays(1))
                 .playStartTime(LocalTime.of(11, 30))
                 .playEndTime(LocalTime.of(13, 0))
                 .playTimeMinutes(90)


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 리뷰 가능 기간을 7일로 정했기 때문에, 이에 따라 경기 종료 후 7일이 지나면 리뷰가 불가능하도록 예외 처리를 추가한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 경기 종료 후 7일이 지나면 리뷰 불가능하도록 예외처리 추가

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
