### PR TITLE
[회원] 포지션 중복 확인 예외 누락 추가

### DIFF
--- a/src/main/java/kr/pickple/back/member/service/MemberService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberService.java
@@ -62,6 +62,7 @@ public class MemberService {
         final Member member = memberCreateRequest.toEntity(mainAddressId);
         final Member savedMember = memberRepository.save(member);
 
+        validatedIsDuplicatedPositions(memberCreateRequest.getPositions());
         final List<MemberPosition> memberPositions = memberCreateRequest.toMemberPositionEntities(savedMember);
 
         memberPositionRepository.saveAll(memberPositions); /* TODO: 벌크 연산으로 고치기 */
@@ -84,6 +85,16 @@ public class MemberService {
         final MainAddress mainAddress = addressReader.readMainAddress(savedMember);
 
         return AuthenticatedMemberResponse.of(savedMember, loginTokens, mainAddress);
+    }
+
+    private void validatedIsDuplicatedPositions(final List<Position> positions) {
+        long distinctPositionsSize = positions.stream()
+                .distinct()
+                .count();
+
+        if (distinctPositionsSize != positions.size()) {
+            throw new MemberException(MEMBER_POSITIONS_IS_DUPLICATED, positions);
+        }
     }
 
     private void validateIsDuplicatedMemberInfo(final MemberCreateRequest memberCreateRequest) {

--- a/src/main/java/kr/pickple/back/member/service/MemberService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberService.java
@@ -88,7 +88,7 @@ public class MemberService {
     }
 
     private void validatedIsDuplicatedPositions(final List<Position> positions) {
-        long distinctPositionsSize = positions.stream()
+        final Long distinctPositionsSize = positions.stream()
                 .distinct()
                 .count();
 


### PR DESCRIPTION
## 👨‍💻 작업 사항
- 연관 관계 분리 후 누락 된 메서드 추가

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 연관 관계 분리 후 멤버를 생성할 때 포지션이 중복으로 들어왔는지 체크하는 로직이 누락되어 추가 함

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X] MemberService에 검증 메서드 추가

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
