### PR TITLE
[게스트 모집] JPA연관관계를 제거하면서 깨진 queryDSL코드 삭제

### DIFF
--- a/src/main/java/kr/pickple/back/address/implement/AddressReader.java
+++ b/src/main/java/kr/pickple/back/address/implement/AddressReader.java
@@ -16,6 +16,7 @@ import kr.pickple.back.address.exception.AddressException;
 import kr.pickple.back.address.repository.AddressDepth1Repository;
 import kr.pickple.back.address.repository.AddressDepth2Repository;
 import kr.pickple.back.address.util.AddressParser;
+import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 
@@ -68,9 +69,19 @@ public class AddressReader {
         return readMainAddressByNames(depthedAddress.get(0), depthedAddress.get(1));
     }
 
-    public MainAddress readMainAddress(final Member member) {
+    public MainAddress readMainAddressByMember(final Member member) {
         final AddressDepth1 addressDepth1 = getAddressDepth1ById(member.getAddressDepth1Id());
         final AddressDepth2 addressDepth2 = getAddressDepth2ById(member.getAddressDepth2Id());
+
+        return MainAddress.builder()
+                .addressDepth1(addressDepth1)
+                .addressDepth2(addressDepth2)
+                .build();
+    }
+
+    public MainAddress readMainAddressByGame(final Game game) {
+        final AddressDepth1 addressDepth1 = getAddressDepth1ById(game.getAddressDepth1Id());
+        final AddressDepth2 addressDepth2 = getAddressDepth2ById(game.getAddressDepth2Id());
 
         return MainAddress.builder()
                 .addressDepth1(addressDepth1)
@@ -96,7 +107,7 @@ public class AddressReader {
                 .orElseThrow(() -> new AddressException(ADDRESS_NOT_FOUND, addressDepth1Id));
     }
 
-    private AddressDepth2 getAddressDepth2ById(final Long addressDepth2Id) {
+    public AddressDepth2 getAddressDepth2ById(final Long addressDepth2Id) {
         return addressDepth2Repository.findById(addressDepth2Id)
                 .orElseThrow(() -> new AddressException(ADDRESS_NOT_FOUND, addressDepth2Id));
     }

--- a/src/main/java/kr/pickple/back/auth/service/OauthService.java
+++ b/src/main/java/kr/pickple/back/auth/service/OauthService.java
@@ -73,7 +73,7 @@ public class OauthService {
                     jwtProperties.getRefreshTokenExpirationTime()
             );
 
-            final MainAddress mainAddress = addressReader.readMainAddress(loginMember);
+            final MainAddress mainAddress = addressReader.readMainAddressByMember(loginMember);
 
             return AuthenticatedMemberResponse.of(loginMember, loginTokens, mainAddress);
         }

--- a/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
@@ -91,7 +91,7 @@ public class CrewMemberService {
                 .map(member -> MemberResponse.of(
                                 member,
                                 getPositionsByMember(member),
-                                addressReader.readMainAddress(member)
+                                addressReader.readMainAddressByMember(member)
                         )
                 )
                 .toList();

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -147,7 +147,7 @@ public class CrewService {
                 .map(member -> MemberResponse.of(
                                 member,
                                 getPositionsByMember(member),
-                                addressReader.readMainAddress(member)
+                                addressReader.readMainAddressByMember(member)
                         )
                 )
                 .toList();

--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -20,8 +20,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
-import kr.pickple.back.address.domain.AddressDepth1;
-import kr.pickple.back.address.domain.AddressDepth2;
 import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.common.domain.BaseEntity;
 import kr.pickple.back.game.exception.GameException;
@@ -91,14 +89,10 @@ public class Game extends BaseEntity {
     private Member host;
 
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "address_depth1_id")
-    private AddressDepth1 addressDepth1;
+    private Long addressDepth1Id;
 
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "address_depth2_id")
-    private AddressDepth2 addressDepth2;
+    private Long addressDepth2Id;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
@@ -117,8 +111,8 @@ public class Game extends BaseEntity {
             final Integer maxMemberCount,
             final Member host,
             final Point point,
-            final AddressDepth1 addressDepth1,
-            final AddressDepth2 addressDepth2
+            final Long addressDepth1Id,
+            final Long addressDepth2Id
     ) {
         this.content = content;
         this.playDate = playDate;
@@ -131,8 +125,8 @@ public class Game extends BaseEntity {
         this.maxMemberCount = maxMemberCount;
         this.host = host;
         this.point = point;
-        this.addressDepth1 = addressDepth1;
-        this.addressDepth2 = addressDepth2;
+        this.addressDepth1Id = addressDepth1Id;
+        this.addressDepth2Id = addressDepth2Id;
     }
 
     public void updateGameStatus(final GameStatus gameStatus) {

--- a/src/main/java/kr/pickple/back/game/dto/request/GameCreateRequest.java
+++ b/src/main/java/kr/pickple/back/game/dto/request/GameCreateRequest.java
@@ -84,8 +84,8 @@ public class GameCreateRequest {
                 .maxMemberCount(maxMemberCount)
                 .host(host)
                 .point(point)
-                .addressDepth1(mainAddress.getAddressDepth1())
-                .addressDepth2(mainAddress.getAddressDepth2())
+                .addressDepth1Id(mainAddress.getAddressDepth1().getId())
+                .addressDepth2Id(mainAddress.getAddressDepth2().getId())
                 .build();
     }
 

--- a/src/main/java/kr/pickple/back/game/dto/response/GameResponse.java
+++ b/src/main/java/kr/pickple/back/game/dto/response/GameResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import kr.pickple.back.address.dto.response.MainAddress;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.game.domain.GameStatus;
 import kr.pickple.back.member.dto.response.MemberResponse;
@@ -40,7 +41,7 @@ public class GameResponse {
     private List<MemberResponse> members;
 
     public static GameResponse of(final Game game, final List<MemberResponse> memberResponses,
-            List<Position> positions) {
+            final List<Position> positions, final MainAddress mainAddress) {
         return GameResponse.builder()
                 .id(game.getId())
                 .content(game.getContent())
@@ -58,8 +59,8 @@ public class GameResponse {
                 .memberCount(game.getMemberCount())
                 .maxMemberCount(game.getMaxMemberCount())
                 .host(getHostResponse(memberResponses, game.getHost().getId()))
-                .addressDepth1(game.getAddressDepth1().getName())
-                .addressDepth2(game.getAddressDepth2().getName())
+                .addressDepth1(mainAddress.getAddressDepth1().getName())
+                .addressDepth2(mainAddress.getAddressDepth2().getName())
                 .positions(positions)
                 .members(memberResponses)
                 .build();

--- a/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameSearchRepositoryImpl.java
@@ -30,9 +30,6 @@ public class GameSearchRepositoryImpl implements GameSearchRepository {
 
         return jpaQueryFactory
                 .selectFrom(game)
-                .join(game.host).fetchJoin()
-                .join(game.addressDepth1).fetchJoin()
-                .join(game.addressDepth2).fetchJoin()
                 .where(isWithInDistance(pointWKT, distance))
                 .orderBy(getOrderByDistance(pointWKT))
                 .fetch();

--- a/src/main/java/kr/pickple/back/game/service/GameMemberService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameMemberService.java
@@ -92,7 +92,7 @@ public class GameMemberService {
             throw new GameException(GAME_MEMBER_IS_NOT_HOST, loggedInMemberId);
         }
 
-        return GameResponse.of(game, getMemberResponsesByStatus(game, status), getPositionsByGame(game));
+        return GameResponse.of(game, getMemberResponsesByStatus(game, status), getPositionsByGame(game), addressReader.readMainAddressByGame(game));
     }
 
     private List<MemberResponse> getMemberResponsesByStatus(final Game game, final RegistrationStatus status) {
@@ -102,7 +102,7 @@ public class GameMemberService {
                 .map(member -> MemberResponse.of(
                                 member,
                                 getPositionsByMember(member),
-                                addressReader.readMainAddress(member)
+                                addressReader.readMainAddressByMember(member)
                         )
                 )
                 .toList();

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.pickple.back.address.dto.response.MainAddress;
 import kr.pickple.back.address.implement.AddressReader;
-import kr.pickple.back.address.service.AddressService;
 import kr.pickple.back.address.service.kakao.KakaoAddressSearchClient;
 import kr.pickple.back.auth.repository.RedisRepository;
 import kr.pickple.back.chat.domain.ChatRoom;
@@ -58,7 +57,6 @@ public class GameService {
     private final MemberPositionRepository memberPositionRepository;
     private final MemberRepository memberRepository;
     private final KakaoAddressSearchClient kakaoAddressSearchClient;
-    private final AddressService addressService;
     private final ChatRoomService chatRoomService;
     private final RedisRepository redisRepository;
     private final GamePositionRepository gamePositionRepository;
@@ -105,7 +103,7 @@ public class GameService {
 
     private String makeGameRoomName(final Game game) {
         final String playDateFormat = game.getPlayDate().format(DateTimeFormatter.ofPattern("MM.dd"));
-        final String addressDepth2Name = game.getAddressDepth2().getName();
+        final String addressDepth2Name = addressReader.getAddressDepth2ById(game.getAddressDepth2Id()).getName();
 
         return MessageFormat.format("{0} {1}", playDateFormat, addressDepth2Name);
     }
@@ -159,7 +157,7 @@ public class GameService {
         final Game game = gameRepository.getGameById(gameId);
         game.increaseViewCount();
 
-        return GameResponse.of(game, getMemberResponsesByStatus(game, CONFIRMED), getPositionsByGame(game));
+        return GameResponse.of(game, getMemberResponsesByStatus(game, CONFIRMED), getPositionsByGame(game), addressReader.readMainAddressByGame(game));
     }
 
     /**
@@ -202,7 +200,7 @@ public class GameService {
 
         return games.stream()
                 .map(game -> GameResponse.of(game, getMemberResponsesByStatus(game, CONFIRMED),
-                        getPositionsByGame(game)))
+                        getPositionsByGame(game), addressReader.readMainAddressByGame(game)))
                 .toList();
     }
 
@@ -218,7 +216,7 @@ public class GameService {
         return games.stream()
                 .filter(Game::isNotEndedGame)
                 .map(game -> GameResponse.of(game, getMemberResponsesByStatus(game, CONFIRMED),
-                        getPositionsByGame(game)))
+                        getPositionsByGame(game), addressReader.readMainAddressByGame(game)))
                 .toList();
     }
 
@@ -235,7 +233,7 @@ public class GameService {
         return games.stream()
                 .filter(Game::isNotEndedGame)
                 .map(game -> GameResponse.of(game, getMemberResponsesByStatus(game, CONFIRMED),
-                        getPositionsByGame(game)))
+                        getPositionsByGame(game), addressReader.readMainAddressByGame(game)))
                 .toList();
     }
 
@@ -246,7 +244,7 @@ public class GameService {
                 .map(member -> MemberResponse.of(
                                 member,
                                 getPositionsByMember(member),
-                                addressReader.readMainAddress(member)
+                                addressReader.readMainAddressByMember(member)
                         )
                 )
                 .toList();

--- a/src/main/java/kr/pickple/back/member/dto/response/MemberGameResponse.java
+++ b/src/main/java/kr/pickple/back/member/dto/response/MemberGameResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import kr.pickple.back.address.dto.response.MainAddress;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.game.domain.GameMember;
 import kr.pickple.back.game.domain.GameStatus;
@@ -41,7 +42,7 @@ public class MemberGameResponse {
     private List<MemberResponse> members;
 
     public static MemberGameResponse of(final GameMember gameMember, final List<MemberResponse> memberResponses,
-            List<Position> positions) {
+            final List<Position> positions, final MainAddress mainAddress) {
         final Game game = gameMember.getGame();
 
         return MemberGameResponse.builder()
@@ -62,8 +63,8 @@ public class MemberGameResponse {
                 .memberCount(game.getMemberCount())
                 .maxMemberCount(game.getMaxMemberCount())
                 .host(getHostResponse(memberResponses, game.getHost().getId()))
-                .addressDepth1(game.getAddressDepth1().getName())
-                .addressDepth2(game.getAddressDepth2().getName())
+                .addressDepth1(mainAddress.getAddressDepth1().getName())
+                .addressDepth2(mainAddress.getAddressDepth2().getName())
                 .positions(positions)
                 .members(memberResponses)
                 .build();

--- a/src/main/java/kr/pickple/back/member/service/MemberCrewService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberCrewService.java
@@ -96,7 +96,7 @@ public class MemberCrewService {
         return crewMemberRepository.findAllByCrewIdAndStatus(crew.getId(), memberStatus)
                 .stream()
                 .map(CrewMember::getMember)
-                .map(member -> MemberResponse.of(member, getPositions(member), addressReader.readMainAddress(member)))
+                .map(member -> MemberResponse.of(member, getPositions(member), addressReader.readMainAddressByMember(member)))
                 .toList();
     }
 

--- a/src/main/java/kr/pickple/back/member/service/MemberGameService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberGameService.java
@@ -99,7 +99,8 @@ public class MemberGameService {
                         MemberGameResponse.of(
                                 memberGame,
                                 getMemberResponsesByGame(memberGame.getGame(), memberStatus),
-                                getPositionsByMember(memberGame.getMember())
+                                getPositionsByMember(memberGame.getMember()),
+                                addressReader.readMainAddressByGame(memberGame.getGame())
                         )
                 )
                 .toList();
@@ -112,7 +113,7 @@ public class MemberGameService {
                 .map(member -> MemberResponse.of(
                                 member,
                                 getPositionsByMember(member),
-                                addressReader.readMainAddress(member)
+                                addressReader.readMainAddressByMember(member)
                         )
                 )
                 .toList();

--- a/src/main/java/kr/pickple/back/member/service/MemberService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberService.java
@@ -81,7 +81,7 @@ public class MemberService {
                 jwtProperties.getRefreshTokenExpirationTime()
         );
 
-        final MainAddress mainAddress = addressReader.readMainAddress(savedMember);
+        final MainAddress mainAddress = addressReader.readMainAddressByMember(savedMember);
 
         return AuthenticatedMemberResponse.of(savedMember, loginTokens, mainAddress);
     }
@@ -112,14 +112,14 @@ public class MemberService {
                 .map(crew -> CrewResponse.from(crew, getLeaderResponse(crew)))
                 .toList();
 
-        final MainAddress mainAddress = addressReader.readMainAddress(member);
+        final MainAddress mainAddress = addressReader.readMainAddressByMember(member);
 
         return MemberProfileResponse.of(member, crewResponses, positions, mainAddress);
     }
 
     private MemberResponse getLeaderResponse(final Crew crew) {
         final Member member = crew.getLeader();
-        final MainAddress mainAddress = addressReader.readMainAddress(member);
+        final MainAddress mainAddress = addressReader.readMainAddressByMember(member);
 
         return MemberResponse.of(member, getPositionsByMember(member), mainAddress);
     }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
JPA연관관계를 제거하면서 깨진 queryDSL코드 삭제
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] JPA연관관계를 제거하면서 깨진 queryDSL코드 삭제

---


### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
