### PR TITLE
[채팅] Chat 도메인 단방향 연관관계 삭제

### DIFF
--- a/src/main/java/kr/pickple/back/chat/domain/ChatMessage.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatMessage.java
@@ -3,21 +3,18 @@ package kr.pickple.back.chat.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import kr.pickple.back.chat.util.MessageTypeAttributeConverter;
 import kr.pickple.back.common.domain.BaseEntity;
-import kr.pickple.back.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage extends BaseEntity {
@@ -26,33 +23,25 @@ public class ChatMessage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Getter
     @NotNull
     @Convert(converter = MessageTypeAttributeConverter.class)
     private MessageType type;
 
-    @Getter
     @NotNull
     @Column(length = 500)
     private String content;
 
-    @Getter
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sender_id")
-    private Member sender;
+    private Long senderId;
 
-    @Getter
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id")
-    private ChatRoom chatRoom;
+    private Long chatRoomId;
 
     @Builder
-    private ChatMessage(final ChatRoom chatRoom, final Member sender, final String content, final MessageType type) {
+    private ChatMessage(final MessageType type, final String content, final Long senderId, final Long chatRoomId) {
         this.type = type;
         this.content = content;
-        this.chatRoom = chatRoom;
-        this.sender = sender;
+        this.senderId = senderId;
+        this.chatRoomId = chatRoomId;
     }
 }

--- a/src/main/java/kr/pickple/back/chat/domain/ChatRoom.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatRoom.java
@@ -17,30 +17,26 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom extends BaseEntity {
 
     @Id
-    @Getter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Getter
     @NotNull
     @Column(length = 20)
     private String name;
 
-    @Getter
     @NotNull
     @Convert(converter = RoomTypeAttributeConverter.class)
     private RoomType type;
 
-    @Getter
     @NotNull
     private Integer memberCount = 0;
 
-    @Getter
     @NotNull
     private Integer maxMemberCount = 2;
 

--- a/src/main/java/kr/pickple/back/chat/domain/ChatRoomMember.java
+++ b/src/main/java/kr/pickple/back/chat/domain/ChatRoomMember.java
@@ -2,18 +2,15 @@ package kr.pickple.back.chat.domain;
 
 import static java.lang.Boolean.*;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import kr.pickple.back.common.domain.BaseEntity;
-import kr.pickple.back.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -23,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "chat_room_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = {"member", "chatRoom"}, callSuper = false)
+@EqualsAndHashCode(of = {"memberId", "chatRoomId"}, callSuper = false)
 public class ChatRoomMember extends BaseEntity {
 
     @Id
@@ -35,20 +32,18 @@ public class ChatRoomMember extends BaseEntity {
 
     @Getter
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @Getter
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id")
-    private ChatRoom chatRoom;
+    @Column(name = "chat_room_id")
+    private Long chatRoomId;
 
     @Builder
-    private ChatRoomMember(final Member member, final ChatRoom chatRoom) {
-        this.member = member;
-        this.chatRoom = chatRoom;
+    private ChatRoomMember(final Long memberId, final Long chatRoomId) {
+        this.memberId = memberId;
+        this.chatRoomId = chatRoomId;
     }
 
     public void activate() {

--- a/src/main/java/kr/pickple/back/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/kr/pickple/back/chat/dto/response/ChatMessageResponse.java
@@ -3,7 +3,9 @@ package kr.pickple.back.chat.dto.response;
 import java.time.LocalDateTime;
 
 import kr.pickple.back.chat.domain.ChatMessage;
+import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.chat.domain.MessageType;
+import kr.pickple.back.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,12 +22,12 @@ public class ChatMessageResponse {
     private Long roomId;
     private LocalDateTime createdAt;
 
-    public static ChatMessageResponse from(final ChatMessage chatMessage) {
+    public static ChatMessageResponse of(final ChatMessage chatMessage, final Member sender, final ChatRoom chatRoom) {
         return ChatMessageResponse.builder()
                 .type(chatMessage.getType())
                 .content(chatMessage.getContent())
-                .sender(ChatMemberResponse.from(chatMessage.getSender()))
-                .roomId(chatMessage.getChatRoom().getId())
+                .sender(ChatMemberResponse.from(sender))
+                .roomId(chatRoom.getId())
                 .createdAt(chatMessage.getCreatedAt())
                 .build();
     }

--- a/src/main/java/kr/pickple/back/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/kr/pickple/back/chat/repository/ChatMessageRepository.java
@@ -17,7 +17,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Query("""
                 select cm
                 from ChatMessage cm
-                where cm.sender.id = :senderId and cm.type = kr.pickple.back.chat.domain.MessageType.ENTER
+                where cm.senderId= :senderId and cm.type = kr.pickple.back.chat.domain.MessageType.ENTER
                 order by cm.createdAt desc
                 limit 1
             """)

--- a/src/main/java/kr/pickple/back/chat/service/ChatRoomService.java
+++ b/src/main/java/kr/pickple/back/chat/service/ChatRoomService.java
@@ -58,7 +58,7 @@ public class ChatRoomService {
     private List<ChatMemberResponse> getChatMemberResponses(final ChatRoom chatRoom) {
         return chatRoomMemberRepository.findAllByActiveTrueAndChatRoomId(chatRoom.getId())
                 .stream()
-                .map(ChatRoomMember::getMember)
+                .map(chatRoomMember -> memberRepository.getMemberById(chatRoomMember.getMemberId()))
                 .map(ChatMemberResponse::from)
                 .toList();
     }
@@ -90,11 +90,15 @@ public class ChatRoomService {
 
         final ChatRoomMember foundChatRoomMember = chatRoomMemberRepository.findAllByMemberId(sender.getId())
                 .stream()
-                .filter(chatRoomMember -> existsReceiverInPersonalChatRoom(receiver, chatRoomMember.getChatRoom()))
+                .filter(chatRoomMember -> existsReceiverInPersonalChatRoom(
+                                receiver,
+                                chatRoomRepository.getChatRoomById(chatRoomMember.getChatRoomId())
+                        )
+                )
                 .findFirst()
                 .orElseThrow(() -> new ChatException(CHAT_ROOM_NOT_FOUND));
 
-        final Long personalChatRoomId = foundChatRoomMember.getChatRoom().getId();
+        final Long personalChatRoomId = foundChatRoomMember.getChatRoomId();
         final Boolean isSenderActive = foundChatRoomMember.isActive();
 
         return PersonalChatRoomExistedResponse.of(personalChatRoomId, isSenderActive);

--- a/src/main/java/kr/pickple/back/chat/service/ChatValidator.java
+++ b/src/main/java/kr/pickple/back/chat/service/ChatValidator.java
@@ -58,7 +58,7 @@ public class ChatValidator {
     }
 
     private void validateCrewChatRoomLeavingConditions(final Member member, final ChatRoom chatRoom) {
-        final Optional<Crew> optionalCrew = crewRepository.findByChatRoom(chatRoom);
+        final Optional<Crew> optionalCrew = crewRepository.findByChatRoomId(chatRoom.getId());
 
         if (optionalCrew.isEmpty()) {
             return;
@@ -75,7 +75,7 @@ public class ChatValidator {
     }
 
     private void validateGameChatRoomLeavingConditions(final Member member, final ChatRoom chatRoom) {
-        final Optional<Game> optionalGame = gameRepository.findByChatRoom(chatRoom);
+        final Optional<Game> optionalGame = gameRepository.findByChatRoomId(chatRoom.getId());
 
         if (optionalGame.isEmpty()) {
             return;

--- a/src/main/java/kr/pickple/back/crew/domain/Crew.java
+++ b/src/main/java/kr/pickple/back/crew/domain/Crew.java
@@ -6,12 +6,9 @@ import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
 import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.common.domain.BaseEntity;
@@ -72,9 +69,7 @@ public class Crew extends BaseEntity {
     @NotNull
     private Long addressDepth2Id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id")
-    private ChatRoom chatRoom;
+    private Long chatRoomId;
 
     @Builder
     private Crew(
@@ -144,6 +139,6 @@ public class Crew extends BaseEntity {
 
     public void makeNewCrewChatRoom(final ChatRoom chatRoom) {
         chatRoom.updateMaxMemberCount(maxMemberCount);
-        this.chatRoom = chatRoom;
+        this.chatRoomId = chatRoom.getId();
     }
 }

--- a/src/main/java/kr/pickple/back/crew/domain/CrewMember.java
+++ b/src/main/java/kr/pickple/back/crew/domain/CrewMember.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
-import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.common.domain.BaseEntity;
 import kr.pickple.back.common.domain.RegistrationStatus;
 import kr.pickple.back.common.util.RegistrationStatusAttributeConverter;
@@ -50,9 +49,5 @@ public class CrewMember extends BaseEntity {
 
     public void updateStatus(final RegistrationStatus status) {
         this.status = status;
-    }
-
-    public ChatRoom getCrewChatRoom() {
-        return crew.getChatRoom();
     }
 }

--- a/src/main/java/kr/pickple/back/crew/repository/CrewRepository.java
+++ b/src/main/java/kr/pickple/back/crew/repository/CrewRepository.java
@@ -9,9 +9,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import kr.pickple.back.address.domain.AddressDepth1;
-import kr.pickple.back.address.domain.AddressDepth2;
-import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.exception.CrewException;
 
@@ -19,13 +16,13 @@ public interface CrewRepository extends JpaRepository<Crew, Long> {
 
     Boolean existsByName(final String name);
 
-    Page<Crew> findByAddressDepth1AndAddressDepth2(
-            final AddressDepth1 addressDepth1,
-            final AddressDepth2 addressDepth2,
+    Page<Crew> findByAddressDepth1IdAndAddressDepth2Id(
+            final Long addressDepth1Id,
+            final Long addressDepth2Id,
             final Pageable pageable
     );
 
-    Optional<Crew> findByChatRoom(final ChatRoom chatRoom);
+    Optional<Crew> findByChatRoomId(final Long chatRoomId);
 
     List<Crew> findAllByLeaderId(final Long leaderId);
 

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -133,9 +133,9 @@ public class CrewService {
     ) {
         final MainAddress mainAddress = addressReader.readMainAddressByNames(addressDepth1, addressDepth2);
 
-        final Page<Crew> crews = crewRepository.findByAddressDepth1AndAddressDepth2(
-                mainAddress.getAddressDepth1(),
-                mainAddress.getAddressDepth2(),
+        final Page<Crew> crews = crewRepository.findByAddressDepth1IdAndAddressDepth2Id(
+                mainAddress.getAddressDepth1().getId(),
+                mainAddress.getAddressDepth2().getId(),
                 pageable
         );
 

--- a/src/main/java/kr/pickple/back/game/domain/Game.java
+++ b/src/main/java/kr/pickple/back/game/domain/Game.java
@@ -18,7 +18,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
 import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.common.domain.BaseEntity;
@@ -94,9 +93,7 @@ public class Game extends BaseEntity {
     @NotNull
     private Long addressDepth2Id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id")
-    private ChatRoom chatRoom;
+    private Long chatRoomId;
 
     @Builder
     private Game(
@@ -179,6 +176,6 @@ public class Game extends BaseEntity {
 
     public void makeNewCrewChatRoom(final ChatRoom chatRoom) {
         chatRoom.updateMaxMemberCount(maxMemberCount);
-        this.chatRoom = chatRoom;
+        this.chatRoomId = chatRoom.getId();
     }
 }

--- a/src/main/java/kr/pickple/back/game/domain/GameMember.java
+++ b/src/main/java/kr/pickple/back/game/domain/GameMember.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
-import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.common.domain.BaseEntity;
 import kr.pickple.back.common.domain.RegistrationStatus;
 import kr.pickple.back.common.util.RegistrationStatusAttributeConverter;
@@ -67,10 +66,6 @@ public class GameMember extends BaseEntity {
         }
 
         this.status = status;
-    }
-
-    public ChatRoom getCrewChatRoom() {
-        return game.getChatRoom();
     }
 
     public Boolean isAlreadyReviewDone() {

--- a/src/main/java/kr/pickple/back/game/repository/GameRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GameRepository.java
@@ -8,8 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import kr.pickple.back.address.domain.AddressDepth1;
-import kr.pickple.back.address.domain.AddressDepth2;
 import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.game.domain.GameStatus;
@@ -17,14 +15,14 @@ import kr.pickple.back.game.exception.GameException;
 
 public interface GameRepository extends JpaRepository<Game, Long>, GameSearchRepository {
 
-    Page<Game> findByAddressDepth1AndAddressDepth2AndStatusNot(
-            final AddressDepth1 addressDepth1,
-            final AddressDepth2 addressDepth2,
+    Page<Game> findByAddressDepth1IdAndAddressDepth2IdAndStatusNot(
+            final Long addressDepth1Id,
+            final Long addressDepth2Id,
             final GameStatus status,
             final Pageable pageable
     );
 
-    Optional<Game> findByChatRoom(final ChatRoom chatRoom);
+    Optional<Game> findByChatRoomId(final Long chatRoomId);
 
     default Game getGameById(final Long gameId) {
         return findById(gameId).orElseThrow(() -> new GameException(GAME_NOT_FOUND, gameId));

--- a/src/main/java/kr/pickple/back/game/service/GameMemberService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameMemberService.java
@@ -13,6 +13,8 @@ import kr.pickple.back.address.implement.AddressReader;
 import kr.pickple.back.alarm.event.game.GameJoinRequestNotificationEvent;
 import kr.pickple.back.alarm.event.game.GameMemberJoinedEvent;
 import kr.pickple.back.alarm.event.game.GameMemberRejectedEvent;
+import kr.pickple.back.chat.domain.ChatRoom;
+import kr.pickple.back.chat.repository.ChatRoomRepository;
 import kr.pickple.back.chat.service.ChatMessageService;
 import kr.pickple.back.common.domain.RegistrationStatus;
 import kr.pickple.back.game.domain.Game;
@@ -42,6 +44,7 @@ public class GameMemberService {
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
     private final MemberPositionRepository memberPositionRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageService chatMessageService;
     private final ApplicationEventPublisher eventPublisher;
     private final GameMemberRepository gameMemberRepository;
@@ -144,7 +147,8 @@ public class GameMemberService {
         validateIsHost(loggedInMemberId, game);
 
         final RegistrationStatus updateStatus = gameMemberRegistrationStatusUpdateRequest.getStatus();
-        enterGameChatRoom(updateStatus, gameMember);
+        final ChatRoom chatRoom = chatRoomRepository.getChatRoomById(game.getChatRoomId());
+        enterGameChatRoom(updateStatus, gameMember, chatRoom);
 
         gameMember.updateStatus(updateStatus);
 
@@ -162,11 +166,15 @@ public class GameMemberService {
         }
     }
 
-    private void enterGameChatRoom(final RegistrationStatus updateStatus, final GameMember gameMember) {
+    private void enterGameChatRoom(
+            final RegistrationStatus updateStatus,
+            final GameMember gameMember,
+            final ChatRoom chatRoom
+    ) {
         final RegistrationStatus nowStatus = gameMember.getStatus();
 
         if (nowStatus == WAITING && updateStatus == CONFIRMED) {
-            chatMessageService.enterRoomAndSaveEnteringMessages(gameMember.getCrewChatRoom(), gameMember.getMember());
+            chatMessageService.enterRoomAndSaveEnteringMessages(chatRoom, gameMember.getMember());
         }
     }
 

--- a/src/main/java/kr/pickple/back/game/service/GameService.java
+++ b/src/main/java/kr/pickple/back/game/service/GameService.java
@@ -77,7 +77,8 @@ public class GameService {
     public GameIdResponse createGame(final GameCreateRequest gameCreateRequest, final Long loggedInMemberId) {
         final Member host = memberRepository.getMemberById(loggedInMemberId);
         final Point point = kakaoAddressSearchClient.fetchAddress(gameCreateRequest.getMainAddress());
-        final MainAddress mainAddress = addressReader.readMainAddressByAddressStrings(gameCreateRequest.getMainAddress());
+        final MainAddress mainAddress = addressReader.readMainAddressByAddressStrings(
+                gameCreateRequest.getMainAddress());
 
         final Game game = gameCreateRequest.toEntity(host, mainAddress, point);
         final GameMember gameHost = GameMember.builder()
@@ -195,9 +196,9 @@ public class GameService {
                 )
         );
 
-        final Page<Game> games = gameRepository.findByAddressDepth1AndAddressDepth2AndStatusNot(
-                mainAddress.getAddressDepth1(),
-                mainAddress.getAddressDepth2(),
+        final Page<Game> games = gameRepository.findByAddressDepth1IdAndAddressDepth2IdAndStatusNot(
+                mainAddress.getAddressDepth1().getId(),
+                mainAddress.getAddressDepth2().getId(),
                 GameStatus.ENDED,
                 pageRequest
         );


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- Chat 도메인 단방향 연관관계 삭제한다.
---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] Chat 도메인 관련 ManyToOne 모두 제거
- [x] Chat - Crew, Chat - Game의 OneToOne 모두 제거

---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
