### PR TITLE
[회원, 크루] CrewMapper, MemberMapper에서 DB 의존성 모두 제거

### DIFF
--- a/src/main/java/kr/pickple/back/crew/controller/CrewController.java
+++ b/src/main/java/kr/pickple/back/crew/controller/CrewController.java
@@ -19,10 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import kr.pickple.back.auth.config.resolver.Login;
 import kr.pickple.back.common.domain.RegistrationStatus;
-import kr.pickple.back.crew.domain.Crew;
-import kr.pickple.back.crew.domain.NewCrew;
-import kr.pickple.back.crew.dto.mapper.CrewRequestMapper;
-import kr.pickple.back.crew.dto.mapper.CrewResponseMapper;
 import kr.pickple.back.crew.dto.request.CrewCreateRequest;
 import kr.pickple.back.crew.dto.request.CrewMemberUpdateStatusRequest;
 import kr.pickple.back.crew.dto.response.CrewIdResponse;
@@ -44,23 +40,16 @@ public class CrewController {
             @Login final Long loggedInMemberId,
             @Valid @RequestBody final CrewCreateRequest crewCreateRequest
     ) {
-        final NewCrew newCrew = CrewRequestMapper.mapToNewCrewDomain(crewCreateRequest);
-        final Long crewId = crewService.createCrew(loggedInMemberId, newCrew);
-        final CrewIdResponse crewIdResponse = CrewResponseMapper.mapToCrewIdResponseDto(crewId);
-
         return ResponseEntity.status(CREATED)
-                .body(crewIdResponse);
+                .body(crewService.createCrew(loggedInMemberId, crewCreateRequest));
     }
 
     @GetMapping("/{crewId}")
     public ResponseEntity<CrewProfileResponse> findCrewById(
             @PathVariable final Long crewId
     ) {
-        final Crew crew = crewService.findCrewById(crewId);
-        final CrewProfileResponse crewProfileResponse = CrewResponseMapper.mapToCrewProfileResponseDto(crew);
-
         return ResponseEntity.status(OK)
-                .body(crewProfileResponse);
+                .body(crewService.findCrewById(crewId));
     }
 
     @PostMapping("/{crewId}/members")
@@ -80,11 +69,8 @@ public class CrewController {
             @PathVariable final Long crewId,
             @RequestParam final RegistrationStatus status
     ) {
-        final Crew crew = crewMemberService.findCrewMembersByStatus(loggedInMemberId, crewId, status);
-        final CrewProfileResponse crewProfileResponse = CrewResponseMapper.mapToCrewProfileResponseDto(crew);
-
         return ResponseEntity.status(OK)
-                .body(crewProfileResponse);
+                .body(crewMemberService.findCrewMembersByStatus(loggedInMemberId, crewId, status));
     }
 
     @PatchMapping("/{crewId}/members/{memberId}")
@@ -123,12 +109,7 @@ public class CrewController {
             @RequestParam final String addressDepth2,
             final Pageable pageable
     ) {
-        final List<Crew> nearCrews = crewService.findNearCrewsByAddress(addressDepth1, addressDepth2, pageable);
-        final List<CrewProfileResponse> crewProfileResponses = nearCrews.stream()
-                .map(CrewResponseMapper::mapToCrewProfileResponseDto)
-                .toList();
-
         return ResponseEntity.status(OK)
-                .body(crewProfileResponses);
+                .body(crewService.findNearCrewsByAddress(addressDepth1, addressDepth2, pageable));
     }
 }

--- a/src/main/java/kr/pickple/back/crew/domain/Crew.java
+++ b/src/main/java/kr/pickple/back/crew/domain/Crew.java
@@ -3,8 +3,6 @@ package kr.pickple.back.crew.domain;
 import static kr.pickple.back.crew.domain.CrewStatus.*;
 import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
 
-import java.util.List;
-
 import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.crew.exception.CrewException;
 import kr.pickple.back.member.domain.MemberDomain;
@@ -34,7 +32,6 @@ public class Crew {
     private Integer likeCount;
     private Integer competitionPoint;
     private ChatRoom chatRoom;
-    private List<MemberDomain> members;
 
     public void increaseMemberCount() {
         if (status == CLOSED) {

--- a/src/main/java/kr/pickple/back/crew/dto/mapper/CrewResponseMapper.java
+++ b/src/main/java/kr/pickple/back/crew/dto/mapper/CrewResponseMapper.java
@@ -6,6 +6,7 @@ import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.dto.response.CrewIdResponse;
 import kr.pickple.back.crew.dto.response.CrewProfileResponse;
 import kr.pickple.back.crew.dto.response.CrewResponse;
+import kr.pickple.back.member.domain.MemberDomain;
 import kr.pickple.back.member.dto.mapper.MemberResponseMapper;
 import kr.pickple.back.member.dto.response.MemberResponse;
 import lombok.AccessLevel;
@@ -18,9 +19,8 @@ public final class CrewResponseMapper {
         return CrewIdResponse.from(crewId);
     }
 
-    public static CrewProfileResponse mapToCrewProfileResponseDto(final Crew crew) {
-        final List<MemberResponse> memberResponses = crew.getMembers()
-                .stream()
+    public static CrewProfileResponse mapToCrewProfileResponseDto(final Crew crew, final List<MemberDomain> members) {
+        final List<MemberResponse> memberResponses = members.stream()
                 .map(MemberResponseMapper::mapToMemberResponseDto)
                 .toList();
 

--- a/src/main/java/kr/pickple/back/crew/implement/CrewMapper.java
+++ b/src/main/java/kr/pickple/back/crew/implement/CrewMapper.java
@@ -1,44 +1,20 @@
 package kr.pickple.back.crew.implement;
 
-import static kr.pickple.back.common.domain.RegistrationStatus.*;
-import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
-
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import kr.pickple.back.address.dto.response.MainAddress;
-import kr.pickple.back.address.implement.AddressReader;
-import kr.pickple.back.chat.repository.ChatRoomRepository;
-import kr.pickple.back.common.domain.RegistrationStatus;
+import kr.pickple.back.chat.domain.ChatRoom;
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.domain.CrewMember;
 import kr.pickple.back.crew.domain.NewCrew;
-import kr.pickple.back.crew.exception.CrewException;
-import kr.pickple.back.crew.repository.CrewMemberRepository;
-import kr.pickple.back.crew.repository.CrewRepository;
 import kr.pickple.back.crew.repository.entity.CrewEntity;
 import kr.pickple.back.crew.repository.entity.CrewMemberEntity;
 import kr.pickple.back.member.domain.MemberDomain;
-import kr.pickple.back.member.implement.MemberReader;
-import lombok.RequiredArgsConstructor;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@Component
-@RequiredArgsConstructor
-public class CrewMapper {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CrewMapper {
 
-    private final AddressReader addressReader;
-    private final MemberReader memberReader;
-    private final CrewRepository crewRepository;
-    private final CrewMemberRepository crewMemberRepository;
-    private final ChatRoomRepository chatRoomRepository;
-
-    public CrewEntity mapNewCrewDomainToEntity(final NewCrew newCrew) {
-        final MainAddress mainAddress = addressReader.readMainAddressByNames(
-                newCrew.getAddressDepth1Name(),
-                newCrew.getAddressDepth2Name()
-        );
-
+    public static CrewEntity mapNewCrewDomainToEntity(final NewCrew newCrew, final MainAddress mainAddress) {
         return CrewEntity.builder()
                 .name(newCrew.getName())
                 .content(newCrew.getContent())
@@ -52,36 +28,30 @@ public class CrewMapper {
                 .build();
     }
 
-    public Crew mapCrewEntityToDomain(final CrewEntity crewEntity, final RegistrationStatus status) {
-        final MainAddress mainAddress = addressReader.readMainAddressById(
-                crewEntity.getAddressDepth1Id(),
-                crewEntity.getAddressDepth2Id()
-        );
-
-        final List<MemberDomain> members = crewMemberRepository.findAllByCrewIdAndStatus(crewEntity.getId(), status)
-                .stream()
-                .map(crewMember -> memberReader.readByMemberId(crewMember.getMemberId()))
-                .toList();
-
+    public static Crew mapCrewEntityToDomain(
+            final CrewEntity crewEntity,
+            final MainAddress mainAddress,
+            final MemberDomain leader,
+            final ChatRoom chatRoom
+    ) {
         return Crew.builder()
                 .crewId(crewEntity.getId())
                 .name(crewEntity.getName())
                 .content(crewEntity.getContent())
                 .memberCount(crewEntity.getMemberCount())
                 .maxMemberCount(crewEntity.getMaxMemberCount())
-                .leader(memberReader.readByMemberId(crewEntity.getLeaderId()))
+                .leader(leader)
                 .addressDepth1Name(mainAddress.getAddressDepth1().getName())
                 .addressDepth2Name(mainAddress.getAddressDepth2().getName())
                 .profileImageUrl(crewEntity.getProfileImageUrl())
                 .backgroundImageUrl(crewEntity.getBackgroundImageUrl())
                 .likeCount(crewEntity.getLikeCount())
                 .competitionPoint(crewEntity.getCompetitionPoint())
-                .chatRoom(chatRoomRepository.getChatRoomById(crewEntity.getChatRoomId()))
-                .members(members)
+                .chatRoom(chatRoom)
                 .build();
     }
 
-    public CrewMemberEntity mapCrewMemberDomainToEntity(final CrewMember crewMember) {
+    public static CrewMemberEntity mapCrewMemberDomainToEntity(final CrewMember crewMember) {
         return CrewMemberEntity.builder()
                 .status(crewMember.getStatus())
                 .memberId(crewMember.getMember().getMemberId())
@@ -89,15 +59,16 @@ public class CrewMapper {
                 .build();
     }
 
-    public CrewMember mapCrewMemberEntityToDomain(final CrewMemberEntity crewMemberEntity) {
-        final CrewEntity crewEntity = crewRepository.findById(crewMemberEntity.getCrewId())
-                .orElseThrow(() -> new CrewException(CREW_NOT_FOUND, crewMemberEntity.getCrewId()));
-
+    public static CrewMember mapCrewMemberEntityToDomain(
+            final CrewMemberEntity crewMemberEntity,
+            final MemberDomain member,
+            final Crew crew
+    ) {
         return CrewMember.builder()
                 .crewMemberId(crewMemberEntity.getId())
                 .status(crewMemberEntity.getStatus())
-                .member(memberReader.readByMemberId(crewMemberEntity.getMemberId()))
-                .crew(mapCrewEntityToDomain(crewEntity, CONFIRMED))
+                .member(member)
+                .crew(crew)
                 .build();
     }
 }

--- a/src/main/java/kr/pickple/back/crew/implement/CrewReader.java
+++ b/src/main/java/kr/pickple/back/crew/implement/CrewReader.java
@@ -1,7 +1,7 @@
 package kr.pickple.back.crew.implement;
 
-import static kr.pickple.back.common.domain.RegistrationStatus.*;
 import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
+import static kr.pickple.back.member.exception.MemberExceptionCode.*;
 
 import java.util.List;
 
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.pickple.back.address.dto.response.MainAddress;
 import kr.pickple.back.address.implement.AddressReader;
+import kr.pickple.back.chat.domain.ChatRoom;
+import kr.pickple.back.chat.repository.ChatRoomRepository;
 import kr.pickple.back.common.domain.RegistrationStatus;
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.domain.CrewMember;
@@ -20,6 +22,14 @@ import kr.pickple.back.crew.repository.CrewMemberRepository;
 import kr.pickple.back.crew.repository.CrewRepository;
 import kr.pickple.back.crew.repository.entity.CrewEntity;
 import kr.pickple.back.crew.repository.entity.CrewMemberEntity;
+import kr.pickple.back.member.domain.Member;
+import kr.pickple.back.member.domain.MemberDomain;
+import kr.pickple.back.member.domain.MemberPosition;
+import kr.pickple.back.member.exception.MemberException;
+import kr.pickple.back.member.implement.MemberMapper;
+import kr.pickple.back.member.repository.MemberPositionRepository;
+import kr.pickple.back.member.repository.MemberRepository;
+import kr.pickple.back.position.domain.Position;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -28,26 +38,29 @@ import lombok.RequiredArgsConstructor;
 public class CrewReader {
 
     private final AddressReader addressReader;
-    private final CrewMapper crewMapper;
+    private final MemberRepository memberRepository;
+    private final MemberPositionRepository memberPositionRepository;
     private final CrewRepository crewRepository;
     private final CrewMemberRepository crewMemberRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     public Integer countByLeaderId(final Long leaderId) {
         return crewRepository.countByLeaderId(leaderId);
     }
 
-    public Crew read(final Long crewId, final RegistrationStatus status) {
+    public Crew read(final Long crewId) {
         final CrewEntity crewEntity = crewRepository.findById(crewId)
                 .orElseThrow(() -> new CrewException(CREW_NOT_FOUND, crewId));
 
-        return crewMapper.mapCrewEntityToDomain(crewEntity, status);
-    }
+        final MainAddress mainAddress = addressReader.readMainAddressById(
+                crewEntity.getAddressDepth1Id(),
+                crewEntity.getAddressDepth2Id()
+        );
 
-    public List<Crew> readJoinedCrewsByMemberId(final Long memberId) {
-        return crewMemberRepository.findAllByMemberIdAndStatus(memberId, CONFIRMED)
-                .stream()
-                .map(crewMember -> read(crewMember.getCrewId(), CONFIRMED))
-                .toList();
+        final MemberDomain leader = readMemberById(crewEntity.getLeaderId());
+        final ChatRoom chatRoom = chatRoomRepository.getChatRoomById(crewEntity.getChatRoomId());
+
+        return CrewMapper.mapCrewEntityToDomain(crewEntity, mainAddress, leader, chatRoom);
     }
 
     public List<Crew> readNearCrewsByAddress(
@@ -63,14 +76,45 @@ public class CrewReader {
         );
 
         return crewEntities.stream()
-                .map(crewEntity -> crewMapper.mapCrewEntityToDomain(crewEntity, CONFIRMED))
+                .map(crewEntity -> {
+                    final MemberDomain leader = readMemberById(crewEntity.getLeaderId());
+                    final ChatRoom chatRoom = chatRoomRepository.getChatRoomById(crewEntity.getChatRoomId());
+
+                    return CrewMapper.mapCrewEntityToDomain(crewEntity, mainAddress, leader, chatRoom);
+                })
                 .toList();
     }
 
     public CrewMember readCrewMember(final Long memberId, final Long crewId) {
         final CrewMemberEntity crewMemberEntity = crewMemberRepository.findByMemberIdAndCrewId(memberId, crewId)
                 .orElseThrow(() -> new CrewException(CREW_MEMBER_NOT_FOUND, memberId, crewId));
+        final MemberDomain member = readMemberById(memberId);
+        final Crew crew = read(crewId);
 
-        return crewMapper.mapCrewMemberEntityToDomain(crewMemberEntity);
+        return CrewMapper.mapCrewMemberEntityToDomain(crewMemberEntity, member, crew);
+    }
+
+    public List<MemberDomain> readAllMembersInStatus(final Long crewId, final RegistrationStatus status) {
+        return crewMemberRepository.findAllByCrewIdAndStatus(crewId, status)
+                .stream()
+                .map(crewMemberEntity -> readMemberById(crewMemberEntity.getMemberId()))
+                .toList();
+    }
+
+    private MemberDomain readMemberById(final Long memberId) {
+        final Member memberEntity = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND, memberId));
+
+        final MainAddress mainAddress = addressReader.readMainAddressById(
+                memberEntity.getAddressDepth1Id(),
+                memberEntity.getAddressDepth2Id()
+        );
+
+        final List<Position> positions = memberPositionRepository.findAllByMemberId(memberId)
+                .stream()
+                .map(MemberPosition::getPosition)
+                .toList();
+
+        return MemberMapper.mapToMemberDomain(memberEntity, mainAddress, positions);
     }
 }

--- a/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
@@ -1,7 +1,8 @@
 package kr.pickple.back.crew.service;
 
-import static kr.pickple.back.common.domain.RegistrationStatus.*;
 import static kr.pickple.back.crew.exception.CrewExceptionCode.*;
+
+import java.util.List;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,7 @@ public class CrewMemberService {
      */
     @Transactional
     public void registerCrewMember(final Long crewId, final Long loggedInMemberId) {
-        final Crew crew = crewReader.read(crewId, CONFIRMED);
+        final Crew crew = crewReader.read(crewId);
         final MemberDomain member = memberReader.readByMemberId(loggedInMemberId);
 
         crewWriter.register(member, crew);
@@ -59,13 +60,15 @@ public class CrewMemberService {
             final Long crewId,
             final RegistrationStatus status
     ) {
-        final Crew crew = crewReader.read(crewId, status);
+        final Crew crew = crewReader.read(crewId);
 
         if (!crew.isLeader(loggedInMemberId)) {
             throw new CrewException(CREW_IS_NOT_LEADER, loggedInMemberId);
         }
 
-        return CrewResponseMapper.mapToCrewProfileResponseDto(crew);
+        final List<MemberDomain> members = crewReader.readAllMembersInStatus(crewId, status);
+
+        return CrewResponseMapper.mapToCrewProfileResponseDto(crew, members);
     }
 
     /**

--- a/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewMemberService.java
@@ -14,6 +14,8 @@ import kr.pickple.back.chat.service.ChatMessageService;
 import kr.pickple.back.common.domain.RegistrationStatus;
 import kr.pickple.back.crew.domain.Crew;
 import kr.pickple.back.crew.domain.CrewMember;
+import kr.pickple.back.crew.dto.mapper.CrewResponseMapper;
+import kr.pickple.back.crew.dto.response.CrewProfileResponse;
 import kr.pickple.back.crew.exception.CrewException;
 import kr.pickple.back.crew.implement.CrewReader;
 import kr.pickple.back.crew.implement.CrewWriter;
@@ -52,7 +54,7 @@ public class CrewMemberService {
     /**
      * 크루에 가입 신청된 혹은 확정된 사용자 정보 목록 조회
      */
-    public Crew findCrewMembersByStatus(
+    public CrewProfileResponse findCrewMembersByStatus(
             final Long loggedInMemberId,
             final Long crewId,
             final RegistrationStatus status
@@ -63,7 +65,7 @@ public class CrewMemberService {
             throw new CrewException(CREW_IS_NOT_LEADER, loggedInMemberId);
         }
 
-        return crew;
+        return CrewResponseMapper.mapToCrewProfileResponseDto(crew);
     }
 
     /**

--- a/src/main/java/kr/pickple/back/crew/service/CrewService.java
+++ b/src/main/java/kr/pickple/back/crew/service/CrewService.java
@@ -90,9 +90,10 @@ public class CrewService {
      * 크루 상세 조회
      */
     public CrewProfileResponse findCrewById(final Long crewId) {
-        final Crew crew = crewReader.read(crewId, CONFIRMED);
+        final Crew crew = crewReader.read(crewId);
+        final List<MemberDomain> members = crewReader.readAllMembersInStatus(crewId, CONFIRMED);
 
-        return CrewResponseMapper.mapToCrewProfileResponseDto(crew);
+        return CrewResponseMapper.mapToCrewProfileResponseDto(crew, members);
     }
 
     /**
@@ -105,7 +106,11 @@ public class CrewService {
     ) {
         return crewReader.readNearCrewsByAddress(addressDepth1Name, addressDepth2Name, pageable)
                 .stream()
-                .map(CrewResponseMapper::mapToCrewProfileResponseDto)
+                .map(crew -> {
+                    final List<MemberDomain> members = crewReader.readAllMembersInStatus(crew.getCrewId(), CONFIRMED);
+
+                    return CrewResponseMapper.mapToCrewProfileResponseDto(crew, members);
+                })
                 .toList();
     }
 }

--- a/src/main/java/kr/pickple/back/member/domain/MemberDomain.java
+++ b/src/main/java/kr/pickple/back/member/domain/MemberDomain.java
@@ -2,8 +2,6 @@ package kr.pickple.back.member.domain;
 
 import java.util.List;
 
-import kr.pickple.back.crew.domain.Crew;
-import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.position.domain.Position;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -27,8 +25,6 @@ public class MemberDomain {
     private String addressDepth1Name;
     private String addressDepth2Name;
     private List<Position> positions;
-    private List<Crew> joinedCrews;
-    private List<Game> joinedGames;
 
     public Boolean isIdMatched(final Long memberId) {
         return this.memberId.equals(memberId);

--- a/src/main/java/kr/pickple/back/member/dto/mapper/MemberResponseMapper.java
+++ b/src/main/java/kr/pickple/back/member/dto/mapper/MemberResponseMapper.java
@@ -53,6 +53,17 @@ public final class MemberResponseMapper {
     }
 
     public static MemberResponse mapToMemberResponseDto(final MemberDomain member) {
-        return MemberResponse.of(member);
+        return MemberResponse.builder()
+                .id(member.getMemberId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .profileImageUrl(member.getProfileImageUrl())
+                .mannerScore(member.getMannerScore())
+                .mannerScoreCount(member.getMannerScoreCount())
+                .addressDepth1(member.getAddressDepth1Name())
+                .addressDepth2(member.getAddressDepth2Name())
+                .positions(member.getPositions())
+                .build();
     }
 }

--- a/src/main/java/kr/pickple/back/member/dto/response/MemberResponse.java
+++ b/src/main/java/kr/pickple/back/member/dto/response/MemberResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import kr.pickple.back.address.dto.response.MainAddress;
 import kr.pickple.back.member.domain.Member;
-import kr.pickple.back.member.domain.MemberDomain;
 import kr.pickple.back.position.domain.Position;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -44,21 +43,6 @@ public class MemberResponse {
                 .addressDepth1(mainAddress.getAddressDepth1().getName())
                 .addressDepth2(mainAddress.getAddressDepth2().getName())
                 .positions(positions)
-                .build();
-    }
-
-    public static MemberResponse of(final MemberDomain member) {
-        return MemberResponse.builder()
-                .id(member.getMemberId())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .introduction(member.getIntroduction())
-                .profileImageUrl(member.getProfileImageUrl())
-                .mannerScore(member.getMannerScore())
-                .mannerScoreCount(member.getMannerScoreCount())
-                .addressDepth1(member.getAddressDepth1Name())
-                .addressDepth2(member.getAddressDepth2Name())
-                .positions(member.getPositions())
                 .build();
     }
 }

--- a/src/main/java/kr/pickple/back/member/implement/MemberMapper.java
+++ b/src/main/java/kr/pickple/back/member/implement/MemberMapper.java
@@ -1,36 +1,20 @@
-package kr.pickple.back.member.mapper;
-
-import static kr.pickple.back.common.domain.RegistrationStatus.*;
+package kr.pickple.back.member.implement;
 
 import java.util.List;
 
-import org.springframework.stereotype.Component;
-
 import kr.pickple.back.address.dto.response.MainAddress;
-import kr.pickple.back.address.implement.AddressReader;
-import kr.pickple.back.crew.implement.CrewReader;
-import kr.pickple.back.game.domain.Game;
-import kr.pickple.back.game.repository.GameMemberRepository;
-import kr.pickple.back.game.repository.GameRepository;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.domain.MemberDomain;
 import kr.pickple.back.member.domain.MemberPosition;
 import kr.pickple.back.member.domain.MemberProfile;
 import kr.pickple.back.member.domain.MemberStatus;
 import kr.pickple.back.member.domain.NewMember;
-import kr.pickple.back.member.repository.MemberPositionRepository;
 import kr.pickple.back.position.domain.Position;
-import lombok.RequiredArgsConstructor;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@Component
-@RequiredArgsConstructor
-public class MemberMapper {
-
-    private final AddressReader addressReader;
-    private final CrewReader crewReader;
-    private final MemberPositionRepository memberPositionRepository;
-    private final GameRepository gameRepository;
-    private final GameMemberRepository gameMemberRepository;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MemberMapper {
 
     public static Member mapToMemberEntity(final NewMember newMember, final MainAddress mainAddress) {
         return Member.builder()
@@ -75,25 +59,13 @@ public class MemberMapper {
                 .build();
     }
 
-    public MemberDomain mapToMemberDomain(final Member memberEntity) {
-        final Long memberId = memberEntity.getId();
-        final MainAddress mainAddress = addressReader.readMainAddressById(
-                memberEntity.getAddressDepth1Id(),
-                memberEntity.getAddressDepth2Id()
-        );
-
-        final List<Position> positions = memberPositionRepository.findAllByMemberId(memberId)
-                .stream()
-                .map(MemberPosition::getPosition)
-                .toList();
-
-        final List<Game> joinedGames = gameMemberRepository.findAllByMemberIdAndStatus(memberId, CONFIRMED)
-                .stream()
-                .map(gameMember -> gameRepository.getGameById(gameMember.getGameId()))
-                .toList();
-
+    public static MemberDomain mapToMemberDomain(
+            final Member memberEntity,
+            final MainAddress mainAddress,
+            final List<Position> positions
+    ) {
         return MemberDomain.builder()
-                .memberId(memberId)
+                .memberId(memberEntity.getId())
                 .email(memberEntity.getEmail())
                 .nickname(memberEntity.getNickname())
                 .introduction(memberEntity.getIntroduction())
@@ -103,8 +75,6 @@ public class MemberMapper {
                 .addressDepth1Name(mainAddress.getAddressDepth1().getName())
                 .addressDepth2Name(mainAddress.getAddressDepth2().getName())
                 .positions(positions)
-                .joinedCrews(crewReader.readJoinedCrewsByMemberId(memberId))
-                .joinedGames(joinedGames)
                 .build();
     }
 }

--- a/src/main/java/kr/pickple/back/member/implement/MemberReader.java
+++ b/src/main/java/kr/pickple/back/member/implement/MemberReader.java
@@ -15,7 +15,6 @@ import kr.pickple.back.member.domain.MemberDomain;
 import kr.pickple.back.member.domain.MemberPosition;
 import kr.pickple.back.member.domain.MemberProfile;
 import kr.pickple.back.member.exception.MemberException;
-import kr.pickple.back.member.mapper.MemberMapper;
 import kr.pickple.back.member.repository.MemberPositionRepository;
 import kr.pickple.back.member.repository.MemberRepository;
 import kr.pickple.back.position.domain.Position;
@@ -35,7 +34,17 @@ public class MemberReader {
         final Member memberEntity = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND, memberId));
 
-        return memberMapper.mapToMemberDomain(memberEntity);
+        final MainAddress mainAddress = addressReader.readMainAddressById(
+                memberEntity.getAddressDepth1Id(),
+                memberEntity.getAddressDepth2Id()
+        );
+
+        final List<Position> positions = memberPositionRepository.findAllByMemberId(memberId)
+                .stream()
+                .map(MemberPosition::getPosition)
+                .toList();
+
+        return memberMapper.mapToMemberDomain(memberEntity, mainAddress, positions);
     }
 
     public MemberProfile readProfileByMemberId(final Long memberId) {

--- a/src/main/java/kr/pickple/back/member/implement/MemberWriter.java
+++ b/src/main/java/kr/pickple/back/member/implement/MemberWriter.java
@@ -14,7 +14,6 @@ import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.member.domain.MemberPosition;
 import kr.pickple.back.member.domain.NewMember;
 import kr.pickple.back.member.exception.MemberException;
-import kr.pickple.back.member.mapper.MemberMapper;
 import kr.pickple.back.member.repository.MemberPositionRepository;
 import kr.pickple.back.member.repository.MemberRepository;
 import kr.pickple.back.position.domain.Position;

--- a/src/main/java/kr/pickple/back/member/service/MemberService.java
+++ b/src/main/java/kr/pickple/back/member/service/MemberService.java
@@ -54,7 +54,7 @@ public class MemberService {
         final List<Crew> crews = crewMemberRepository.findAllByMemberIdAndStatus(memberProfile.getMemberId(),
                         CONFIRMED)
                 .stream()
-                .map(crewMember -> crewReader.read(crewMember.getCrewId(), CONFIRMED))
+                .map(crewMember -> crewReader.read(crewMember.getCrewId()))
                 .toList();
 
         memberProfile.updateJoinedCrews(crews);


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- CrewMapper, MemberMapper에서 DB 의존성 모두 제거한다.
- DTO 매핑 작업을 컨트롤러가 아닌 서비스에서 진행한다.
---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
