### PR TITLE
[회원, 게스트 모집] 회원 및 게스트 모집의 포지션이 여러 개 생성될 때 bulk insert되도록 쿼리 최적화

### DIFF
--- a/src/main/java/kr/pickple/back/game/implement/GameMapper.java
+++ b/src/main/java/kr/pickple/back/game/implement/GameMapper.java
@@ -8,7 +8,6 @@ import kr.pickple.back.address.domain.MainAddress;
 import kr.pickple.back.game.domain.Game;
 import kr.pickple.back.game.domain.NewGame;
 import kr.pickple.back.game.repository.entity.GameEntity;
-import kr.pickple.back.game.repository.entity.GamePosition;
 import kr.pickple.back.member.domain.Member;
 import kr.pickple.back.position.domain.Position;
 import lombok.AccessLevel;
@@ -67,14 +66,5 @@ public final class GameMapper {
                 .addressDepth2Id(mainAddress.getAddressDepth2Id())
                 .chatRoomId(newGame.getChatRoom().getChatRoomId())
                 .build();
-    }
-
-    public static List<GamePosition> mapToGamePositionEntities(final List<Position> positions, final Long gameId) {
-        return positions.stream()
-                .map(position -> GamePosition.builder()
-                        .gameId(gameId)
-                        .position(position)
-                        .build()
-                ).toList();
     }
 }

--- a/src/main/java/kr/pickple/back/game/implement/GameWriter.java
+++ b/src/main/java/kr/pickple/back/game/implement/GameWriter.java
@@ -18,6 +18,7 @@ import kr.pickple.back.game.domain.NewGame;
 import kr.pickple.back.game.dto.request.MannerScoreReview;
 import kr.pickple.back.game.exception.GameException;
 import kr.pickple.back.game.repository.GameMemberRepository;
+import kr.pickple.back.game.repository.GamePositionJdbcRepository;
 import kr.pickple.back.game.repository.GamePositionRepository;
 import kr.pickple.back.game.repository.GameRepository;
 import kr.pickple.back.game.repository.entity.GameEntity;
@@ -39,6 +40,7 @@ public class GameWriter {
     private final GameMemberRepository gameMemberRepository;
     private final GamePositionRepository gamePositionRepository;
     private final KakaoAddressSearchClient kakaoAddressSearchClient;
+    private final GamePositionJdbcRepository gamePositionJdbcRepository;
 
     public Game create(final NewGame newGame) {
         final Point point = kakaoAddressSearchClient.fetchAddress(newGame.getMainAddress());
@@ -64,7 +66,7 @@ public class GameWriter {
     private void setPositionsToGame(final List<Position> positions, final Long gameId) {
         validateIsDuplicatedPositions(positions);
 
-        gamePositionRepository.saveAll(GameMapper.mapToGamePositionEntities(positions, gameId));
+        gamePositionJdbcRepository.creatGamePositions(positions, gameId);
     }
 
     private void validateIsDuplicatedPositions(final List<Position> positions) {

--- a/src/main/java/kr/pickple/back/game/repository/GamePositionJdbcRepository.java
+++ b/src/main/java/kr/pickple/back/game/repository/GamePositionJdbcRepository.java
@@ -1,0 +1,43 @@
+package kr.pickple.back.game.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import kr.pickple.back.position.domain.Position;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class GamePositionJdbcRepository {
+
+    private static final String GAME_POSITION_INSERT_SQL = "INSERT INTO game_position (position, game_id) VALUES(?, ?)";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void creatGamePositions(final List<Position> positions, final Long gameId) {
+        jdbcTemplate.batchUpdate(
+                GAME_POSITION_INSERT_SQL,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Position position = positions.get(i);
+                        ps.setString(1, position.getAcronym());
+                        ps.setLong(2, gameId);
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return positions.size();
+                    }
+                }
+        );
+    }
+}
+
+
+

--- a/src/main/java/kr/pickple/back/member/implement/MemberMapper.java
+++ b/src/main/java/kr/pickple/back/member/implement/MemberMapper.java
@@ -9,7 +9,6 @@ import kr.pickple.back.member.domain.MemberProfile;
 import kr.pickple.back.member.domain.MemberStatus;
 import kr.pickple.back.member.domain.NewMember;
 import kr.pickple.back.member.repository.entity.MemberEntity;
-import kr.pickple.back.member.repository.entity.MemberPositionEntity;
 import kr.pickple.back.position.domain.Position;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -28,18 +27,6 @@ public final class MemberMapper {
                 .addressDepth1Id(mainAddress.getAddressDepth1Id())
                 .addressDepth2Id(mainAddress.getAddressDepth2Id())
                 .build();
-    }
-
-    public static List<MemberPositionEntity> mapToMemberPositionEntities(
-            final List<Position> positions,
-            final Long memberId
-    ) {
-        return positions.stream()
-                .map(position -> MemberPositionEntity.builder()
-                        .memberId(memberId)
-                        .position(position)
-                        .build()
-                ).toList();
     }
 
     public static MemberProfile mapToMemberProfileDomain(

--- a/src/main/java/kr/pickple/back/member/implement/MemberWriter.java
+++ b/src/main/java/kr/pickple/back/member/implement/MemberWriter.java
@@ -10,12 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.pickple.back.address.domain.MainAddress;
 import kr.pickple.back.address.implement.AddressReader;
 import kr.pickple.back.auth.implement.TokenManager;
-import kr.pickple.back.member.repository.entity.MemberEntity;
-import kr.pickple.back.member.repository.entity.MemberPositionEntity;
 import kr.pickple.back.member.domain.NewMember;
 import kr.pickple.back.member.exception.MemberException;
+import kr.pickple.back.member.repository.MemberPositionJdbcRepository;
 import kr.pickple.back.member.repository.MemberPositionRepository;
 import kr.pickple.back.member.repository.MemberRepository;
+import kr.pickple.back.member.repository.entity.MemberEntity;
 import kr.pickple.back.position.domain.Position;
 import lombok.RequiredArgsConstructor;
 
@@ -28,6 +28,7 @@ public class MemberWriter {
     private final AddressReader addressReader;
     private final MemberRepository memberRepository;
     private final MemberPositionRepository memberPositionRepository;
+    private final MemberPositionJdbcRepository memberPositionJdbcRepository;
 
     public NewMember create(final NewMember newMember) {
         validateIsDuplicatedMemberInfo(newMember);
@@ -59,9 +60,7 @@ public class MemberWriter {
     private void setPositionsToMember(final List<Position> positions, final Long memberId) {
         validateIsDuplicatedPositions(positions);
 
-        final List<MemberPositionEntity> memberPositions = MemberMapper.mapToMemberPositionEntities(positions, memberId);
-
-        memberPositionRepository.saveAll(memberPositions);
+        memberPositionJdbcRepository.creatMemberPositions(positions, memberId);
     }
 
     private void validateIsDuplicatedPositions(final List<Position> positions) {

--- a/src/main/java/kr/pickple/back/member/repository/MemberPositionJdbcRepository.java
+++ b/src/main/java/kr/pickple/back/member/repository/MemberPositionJdbcRepository.java
@@ -1,0 +1,40 @@
+package kr.pickple.back.member.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import kr.pickple.back.position.domain.Position;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberPositionJdbcRepository {
+
+    private static final String MEMBER_POSITION_INSERT_SQL = "INSERT INTO member_position (position, member_id) VALUES(?, ?)";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void creatMemberPositions(final List<Position> positions, final Long memberId) {
+        jdbcTemplate.batchUpdate(
+                MEMBER_POSITION_INSERT_SQL,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Position position = positions.get(i);
+                        ps.setString(1, position.getAcronym());
+                        ps.setLong(2, memberId);
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return positions.size();
+                    }
+                }
+        );
+    }
+}


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 회원 및 게스트 모집의 포지션이 여러 개 생성될 때 bulk insert되도록 쿼리 최적화

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [x] 회원의 선호 포지션이 여러 개 생성될 때 bulk insert되도록 쿼리 최적화
- [x] 게스트 모집의 모집 포지션이 여러 개 생성될 때 bulk insert되도록 쿼리 최적화

---

### 🙏 리뷰어에게
<!-- PR에 작성한 변경 사항에 대해 팀원들에게 설명 -->
 -  member가 생성되는 과정에서 선호 포지션(member_position)이 최대 5개 생성됩니다.  기존에는 jpa의 saveAll()을 통해 포지션 데이터들을 저장해왔는데요. 로그를 확인해보니 saveAll()은 5개의 데이터에 대해 각각 insert쿼리가 발생했습니다. 따라서 jdbc의 batchUpdate()메서드를 활용해서 멤버 포지션들을 저장하기 위한 insert쿼리가 한 번만 나가도록 수정했습니다.
 -  게스트 모집의 모집 포지션도 비슷한 케이스라 같이 수정했습니다.

(한번의 insert로 처리되지 못하는 이유를 간략히 설명하자면, insert 완료 후 member_position 엔티티에 id가 맵핑되어야 합니다. 하지만 bulk 형태의 insert 쿼리는 모든 엔티티의 id를 알 수 없습니다. 따라서 insert된 엔티티의 id를 알기 위해서는 row별로 insert쿼리가 실행될 수밖에 없습니다.)  


---

### Prefix
> PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.
- `P1`: 꼭 반영해주세요 (Request changes)
- `P2`: 적극적으로 고려해주세요 (Request changes)
- `P3`: 웬만하면 반영해 주세요 (Comment)
- `P4`: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- `P5`: 그냥 사소한 의견입니다 (Approve)
